### PR TITLE
feat: Add reporting system for mutation testing results

### DIFF
--- a/src/pytest_gremlins/reporting/__init__.py
+++ b/src/pytest_gremlins/reporting/__init__.py
@@ -1,0 +1,21 @@
+"""Reporting module for pytest-gremlins mutation testing results.
+
+This module provides data structures and reporters for presenting
+mutation testing results in various formats (console, HTML, JSON).
+"""
+
+from pytest_gremlins.reporting.console import ConsoleReporter
+from pytest_gremlins.reporting.html import HtmlReporter
+from pytest_gremlins.reporting.json_reporter import JsonReporter
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+from pytest_gremlins.reporting.score import MutationScore
+
+
+__all__ = [
+    'ConsoleReporter',
+    'GremlinResult',
+    'GremlinResultStatus',
+    'HtmlReporter',
+    'JsonReporter',
+    'MutationScore',
+]

--- a/src/pytest_gremlins/reporting/console.py
+++ b/src/pytest_gremlins/reporting/console.py
@@ -1,0 +1,110 @@
+"""Console reporter for gremlin mutation testing results.
+
+Produces human-readable output for terminal display with summary
+statistics and top surviving gremlins.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, TextIO
+
+
+if TYPE_CHECKING:
+    from pytest_gremlins.reporting.score import MutationScore
+
+
+class ConsoleReporter:
+    """Reporter that writes mutation testing results to the console.
+
+    Produces output in the following format:
+
+        ================== pytest-gremlins mutation report ==================
+
+        Zapped: 142 gremlins (89%)
+        Survived: 18 gremlins (11%)
+
+        Top surviving gremlins:
+          src/auth.py:42    >= to >     (boundary not tested)
+          src/utils.py:17   + to -      (arithmetic not verified)
+
+        Run with --gremlin-report=html for detailed report.
+        =====================================================================
+
+    Attributes:
+        output: The file-like object to write to.
+    """
+
+    BORDER_CHAR = '='
+    BORDER_WIDTH = 70
+
+    def __init__(self, output: TextIO | None = None) -> None:
+        """Initialize the console reporter.
+
+        Args:
+            output: File-like object to write to. Defaults to sys.stdout.
+        """
+        self.output = output or sys.stdout
+
+    def write_report(self, score: MutationScore) -> None:
+        """Write the mutation testing report to the output.
+
+        Args:
+            score: The MutationScore containing aggregated results.
+        """
+        self._write_header()
+        self._write_blank_line()
+
+        if score.total == 0:
+            self._write_line('No gremlins tested.')
+        else:
+            self._write_summary(score)
+            self._write_blank_line()
+            self._write_survivors(score)
+
+        self._write_hint()
+        self._write_footer()
+
+    def _write_header(self) -> None:
+        """Write the report header."""
+        title = ' pytest-gremlins mutation report '
+        border_len = (self.BORDER_WIDTH - len(title)) // 2
+        header = f'{self.BORDER_CHAR * border_len}{title}{self.BORDER_CHAR * border_len}'
+        self._write_line(header)
+
+    def _write_footer(self) -> None:
+        """Write the report footer."""
+        self._write_line(self.BORDER_CHAR * self.BORDER_WIDTH)
+
+    def _write_summary(self, score: MutationScore) -> None:
+        """Write the summary statistics."""
+        zapped_pct = round(score.percentage)
+        survived_pct = 100 - zapped_pct if score.total > 0 else 0
+
+        self._write_line(f'Zapped: {score.zapped} gremlins ({zapped_pct}%)')
+        self._write_line(f'Survived: {score.survived} gremlins ({survived_pct}%)')
+
+    def _write_survivors(self, score: MutationScore) -> None:
+        """Write the top surviving gremlins."""
+        survivors = score.top_survivors(limit=10)
+        if not survivors:
+            return
+
+        self._write_line('Top surviving gremlins:')
+        for result in survivors:
+            gremlin = result.gremlin
+            location = f'{gremlin.file_path}:{gremlin.line_number}'
+            self._write_line(f'  {location:<24} {gremlin.description:<16} ({gremlin.operator_name})')
+
+    def _write_hint(self) -> None:
+        """Write hint about detailed report."""
+        self._write_blank_line()
+        self._write_line('Run with --gremlin-report=html for detailed report.')
+
+    def _write_blank_line(self) -> None:
+        """Write a blank line."""
+        self.output.write('\n')
+
+    def _write_line(self, text: str) -> None:
+        """Write a line of text followed by newline."""
+        self.output.write(text + '\n')

--- a/src/pytest_gremlins/reporting/html.py
+++ b/src/pytest_gremlins/reporting/html.py
@@ -1,0 +1,180 @@
+"""HTML reporter for gremlin mutation testing results.
+
+Produces a standalone HTML report with source code annotations
+and visual highlighting of surviving gremlins.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_gremlins.reporting.results import GremlinResult
+    from pytest_gremlins.reporting.score import MutationScore
+
+
+class HtmlReporter:
+    """Reporter that produces standalone HTML reports.
+
+    Generates a self-contained HTML file with embedded CSS for
+    viewing mutation testing results in a browser.
+    """
+
+    def to_html(self, score: MutationScore) -> str:
+        """Convert mutation score to HTML string.
+
+        Args:
+            score: The MutationScore to convert.
+
+        Returns:
+            Complete HTML document as a string.
+        """
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>pytest-gremlins Mutation Report</title>
+    <style>
+        {self._get_styles()}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>pytest-gremlins Mutation Report</h1>
+        {self._render_summary(score)}
+        {self._render_results_table(score)}
+    </div>
+</body>
+</html>"""
+
+    def write_report(self, score: MutationScore, output_path: Path) -> None:
+        """Write mutation report to an HTML file.
+
+        Args:
+            score: The MutationScore to write.
+            output_path: Path to the output HTML file.
+        """
+        output_path.write_text(self.to_html(score))
+
+    def _get_styles(self) -> str:
+        """Get embedded CSS styles."""
+        return """
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: #f5f5f5;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 { color: #2c3e50; margin-top: 0; }
+        .summary {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .stat-card {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .stat-value { font-size: 2em; font-weight: bold; }
+        .stat-label { color: #666; }
+        .stat-zapped .stat-value { color: #27ae60; }
+        .stat-survived .stat-value { color: #e74c3c; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #eee;
+        }
+        th { background: #f8f9fa; font-weight: 600; }
+        tr:hover { background: #f8f9fa; }
+        .status-zapped { color: #27ae60; }
+        .status-survived { color: #e74c3c; font-weight: bold; }
+        .status-timeout { color: #f39c12; }
+        .status-error { color: #9b59b6; }
+        .no-results { text-align: center; color: #666; padding: 40px; }
+        """
+
+    def _render_summary(self, score: MutationScore) -> str:
+        """Render the summary section."""
+        return f"""
+        <div class="summary">
+            <div class="stat-card">
+                <div class="stat-value">{score.total}</div>
+                <div class="stat-label">Total Gremlins</div>
+            </div>
+            <div class="stat-card stat-zapped">
+                <div class="stat-value">{score.zapped}</div>
+                <div class="stat-label">Zapped</div>
+            </div>
+            <div class="stat-card stat-survived">
+                <div class="stat-value">{score.survived}</div>
+                <div class="stat-label">Survived</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">{score.percentage:.0f}%</div>
+                <div class="stat-label">Mutation Score</div>
+            </div>
+        </div>
+        """
+
+    def _render_results_table(self, score: MutationScore) -> str:
+        """Render the results table."""
+        if score.total == 0:
+            return '<div class="no-results">No gremlins tested.</div>'
+
+        rows = '\n'.join(self._render_result_row(r) for r in score.results)
+        return f"""
+        <table>
+            <thead>
+                <tr>
+                    <th>File</th>
+                    <th>Line</th>
+                    <th>Operator</th>
+                    <th>Description</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {rows}
+            </tbody>
+        </table>
+        """
+
+    def _render_result_row(self, result: GremlinResult) -> str:
+        """Render a single result row."""
+        gremlin = result.gremlin
+        status_class = f'status-{result.status.value}'
+        return f'''
+                <tr>
+                    <td>{self._escape_html(gremlin.file_path)}</td>
+                    <td>{gremlin.line_number}</td>
+                    <td>{self._escape_html(gremlin.operator_name)}</td>
+                    <td>{self._escape_html(gremlin.description)}</td>
+                    <td class="{status_class}">{result.status.value}</td>
+                </tr>'''
+
+    def _escape_html(self, text: str) -> str:
+        """Escape HTML special characters."""
+        return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')

--- a/src/pytest_gremlins/reporting/json_reporter.py
+++ b/src/pytest_gremlins/reporting/json_reporter.py
@@ -1,0 +1,146 @@
+"""JSON reporter for gremlin mutation testing results.
+
+Produces machine-readable JSON output for CI integration
+and automated analysis of mutation testing results.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_gremlins.reporting.results import GremlinResult
+    from pytest_gremlins.reporting.score import MutationScore
+
+
+class JsonReporter:
+    """Reporter that produces JSON output for CI integration.
+
+    JSON structure:
+        {
+            "summary": {
+                "total": 10,
+                "zapped": 8,
+                "survived": 2,
+                "timeout": 0,
+                "error": 0,
+                "percentage": 80.0
+            },
+            "files": {
+                "auth.py": {"total": 5, "zapped": 4, "survived": 1, "percentage": 80.0},
+                "utils.py": {"total": 5, "zapped": 4, "survived": 1, "percentage": 80.0}
+            },
+            "results": [
+                {
+                    "gremlin_id": "g001",
+                    "file_path": "auth.py",
+                    "line_number": 42,
+                    "status": "zapped",
+                    "operator": "comparison",
+                    "description": ">= to >",
+                    "killing_test": "test_auth"
+                },
+                ...
+            ]
+        }
+    """
+
+    def to_json(self, score: MutationScore) -> str:
+        """Convert mutation score to JSON string.
+
+        Args:
+            score: The MutationScore to convert.
+
+        Returns:
+            Pretty-printed JSON string.
+        """
+        data = self._build_report_data(score)
+        return json.dumps(data, indent=2)
+
+    def write_report(self, score: MutationScore, output_path: Path) -> None:
+        """Write mutation report to a JSON file.
+
+        Args:
+            score: The MutationScore to write.
+            output_path: Path to the output JSON file.
+        """
+        output_path.write_text(self.to_json(score))
+
+    def _build_report_data(self, score: MutationScore) -> dict[str, Any]:
+        """Build the complete report data structure.
+
+        Args:
+            score: The MutationScore to convert.
+
+        Returns:
+            Dictionary suitable for JSON serialization.
+        """
+        return {
+            'summary': self._build_summary(score),
+            'files': self._build_file_breakdown(score),
+            'results': [self._build_result(r) for r in score.results],
+        }
+
+    def _build_summary(self, score: MutationScore) -> dict[str, Any]:
+        """Build the summary section.
+
+        Args:
+            score: The MutationScore to summarize.
+
+        Returns:
+            Summary dictionary.
+        """
+        return {
+            'total': score.total,
+            'zapped': score.zapped,
+            'survived': score.survived,
+            'timeout': score.timeout,
+            'error': score.error,
+            'percentage': score.percentage,
+        }
+
+    def _build_file_breakdown(self, score: MutationScore) -> dict[str, dict[str, Any]]:
+        """Build per-file breakdown section.
+
+        Args:
+            score: The MutationScore to break down.
+
+        Returns:
+            Dictionary mapping file paths to their stats.
+        """
+        file_scores = score.by_file()
+        return {
+            file_path: {
+                'total': file_score.total,
+                'zapped': file_score.zapped,
+                'survived': file_score.survived,
+                'percentage': file_score.percentage,
+            }
+            for file_path, file_score in file_scores.items()
+        }
+
+    def _build_result(self, result: GremlinResult) -> dict[str, Any]:
+        """Build a single result entry.
+
+        Args:
+            result: The GremlinResult to convert.
+
+        Returns:
+            Dictionary representing this result.
+        """
+        gremlin = result.gremlin
+        entry: dict[str, Any] = {
+            'gremlin_id': gremlin.gremlin_id,
+            'file_path': gremlin.file_path,
+            'line_number': gremlin.line_number,
+            'status': result.status.value,
+            'operator': gremlin.operator_name,
+            'description': gremlin.description,
+        }
+        if result.killing_test is not None:
+            entry['killing_test'] = result.killing_test
+        return entry

--- a/src/pytest_gremlins/reporting/results.py
+++ b/src/pytest_gremlins/reporting/results.py
@@ -1,0 +1,59 @@
+"""GremlinResult dataclass for tracking mutation test outcomes.
+
+Each GremlinResult represents the outcome of testing a single mutation (gremlin).
+Results track whether the gremlin was zapped (caught by tests) or survived
+(test gap found).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pytest_gremlins.instrumentation.gremlin import Gremlin
+
+
+class GremlinResultStatus(Enum):
+    """Status of a gremlin after mutation testing.
+
+    Attributes:
+        ZAPPED: Test caught the mutation (good! tests are working)
+        SURVIVED: Mutation not caught (test gap found)
+        TIMEOUT: Test execution timed out
+        ERROR: Error occurred during test execution
+    """
+
+    ZAPPED = 'zapped'
+    SURVIVED = 'survived'
+    TIMEOUT = 'timeout'
+    ERROR = 'error'
+
+
+@dataclass(frozen=True)
+class GremlinResult:
+    """Result of testing a single gremlin (mutation).
+
+    Attributes:
+        gremlin: The gremlin that was tested.
+        status: Outcome of the mutation test.
+        killing_test: Name of the test that killed this gremlin (if zapped).
+        execution_time_ms: Time taken to test this gremlin in milliseconds.
+    """
+
+    gremlin: Gremlin
+    status: GremlinResultStatus
+    killing_test: str | None = None
+    execution_time_ms: float | None = None
+
+    @property
+    def is_zapped(self) -> bool:
+        """Return True if this gremlin was caught by tests."""
+        return self.status == GremlinResultStatus.ZAPPED
+
+    @property
+    def is_survived(self) -> bool:
+        """Return True if this gremlin escaped the tests."""
+        return self.status == GremlinResultStatus.SURVIVED

--- a/src/pytest_gremlins/reporting/score.py
+++ b/src/pytest_gremlins/reporting/score.py
@@ -1,0 +1,106 @@
+"""Mutation score calculation for gremlin test results.
+
+The mutation score represents test suite effectiveness at catching mutations:
+  score = zapped / total * 100
+
+A higher score means tests are better at catching bugs.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pytest_gremlins.reporting.results import GremlinResult
+
+from pytest_gremlins.reporting.results import GremlinResultStatus
+
+
+@dataclass(frozen=True)
+class MutationScore:
+    """Aggregated mutation testing score.
+
+    Attributes:
+        total: Total number of gremlins tested.
+        zapped: Number of gremlins caught by tests.
+        survived: Number of gremlins that escaped tests.
+        timeout: Number of gremlins that caused test timeouts.
+        error: Number of gremlins that caused errors.
+        results: The underlying list of results.
+    """
+
+    total: int
+    zapped: int
+    survived: int
+    timeout: int
+    error: int
+    results: tuple[GremlinResult, ...]
+
+    @classmethod
+    def from_results(cls, results: Sequence[GremlinResult]) -> MutationScore:
+        """Create a MutationScore from a sequence of GremlinResults.
+
+        Args:
+            results: Sequence of GremlinResult objects to aggregate.
+
+        Returns:
+            MutationScore with counts for each status.
+        """
+        zapped = sum(1 for r in results if r.status == GremlinResultStatus.ZAPPED)
+        survived = sum(1 for r in results if r.status == GremlinResultStatus.SURVIVED)
+        timeout = sum(1 for r in results if r.status == GremlinResultStatus.TIMEOUT)
+        error = sum(1 for r in results if r.status == GremlinResultStatus.ERROR)
+
+        return cls(
+            total=len(results),
+            zapped=zapped,
+            survived=survived,
+            timeout=timeout,
+            error=error,
+            results=tuple(results),
+        )
+
+    @property
+    def percentage(self) -> float:
+        """Calculate mutation score as a percentage.
+
+        The score is (zapped + timeout) / total * 100.
+        Timeouts count as zapped because the test detected something wrong.
+
+        Returns:
+            Mutation score percentage (0.0 to 100.0).
+        """
+        if self.total == 0:
+            return 0.0
+        return (self.zapped + self.timeout) / self.total * 100
+
+    def by_file(self) -> dict[str, MutationScore]:
+        """Break down mutation score by file.
+
+        Returns:
+            Dictionary mapping file paths to their MutationScore.
+        """
+        results_by_file: dict[str, list[GremlinResult]] = defaultdict(list)
+        for result in self.results:
+            results_by_file[result.gremlin.file_path].append(result)
+
+        return {
+            file_path: MutationScore.from_results(file_results) for file_path, file_results in results_by_file.items()
+        }
+
+    def top_survivors(self, limit: int = 10) -> list[GremlinResult]:
+        """Get the top surviving gremlins.
+
+        Args:
+            limit: Maximum number of survivors to return.
+
+        Returns:
+            List of GremlinResult objects for survived gremlins.
+        """
+        survivors = [r for r in self.results if r.is_survived]
+        return survivors[:limit]

--- a/tests/small/reporting/__init__.py
+++ b/tests/small/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the reporting module."""

--- a/tests/small/reporting/test_console.py
+++ b/tests/small/reporting/test_console.py
@@ -1,0 +1,199 @@
+"""Tests for the console reporter."""
+
+from __future__ import annotations
+
+import ast
+from io import StringIO
+
+import pytest
+
+from pytest_gremlins.instrumentation.gremlin import Gremlin
+from pytest_gremlins.reporting.console import ConsoleReporter
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+from pytest_gremlins.reporting.score import MutationScore
+
+
+@pytest.fixture
+def make_gremlin():
+    """Factory fixture for creating test gremlins."""
+    counter = 0
+
+    def _make_gremlin(
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+    ) -> Gremlin:
+        nonlocal counter
+        counter += 1
+        return Gremlin(
+            gremlin_id=f'g{counter:03d}',
+            file_path=file_path,
+            line_number=line_number,
+            original_node=ast.parse('x >= 0', mode='eval').body,
+            mutated_node=ast.parse('x > 0', mode='eval').body,
+            operator_name=operator_name,
+            description=description,
+        )
+
+    return _make_gremlin
+
+
+@pytest.fixture
+def make_result(make_gremlin):
+    """Factory fixture for creating test results."""
+
+    def _make_result(
+        status: GremlinResultStatus = GremlinResultStatus.ZAPPED,
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+    ) -> GremlinResult:
+        gremlin = make_gremlin(
+            file_path=file_path,
+            line_number=line_number,
+            operator_name=operator_name,
+            description=description,
+        )
+        return GremlinResult(gremlin=gremlin, status=status)
+
+    return _make_result
+
+
+class TestConsoleReporter:
+    """Tests for console reporter output."""
+
+    def test_reporter_writes_header(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'pytest-gremlins mutation report' in output_text
+
+    def test_reporter_writes_summary_line(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'Zapped: 2 gremlins' in output_text
+        # 66.67% rounds to 67%
+        assert '67%' in output_text or '66%' in output_text
+
+    def test_reporter_writes_survived_count(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'Survived: 2 gremlins' in output_text
+
+    def test_reporter_writes_top_survivors(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.SURVIVED,
+                file_path='src/auth.py',
+                line_number=42,
+                description='>= to >',
+            ),
+            make_result(
+                GremlinResultStatus.SURVIVED,
+                file_path='src/utils.py',
+                line_number=17,
+                description='+ to -',
+            ),
+        ]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'Top surviving gremlins:' in output_text
+        assert 'src/auth.py:42' in output_text
+        assert 'src/utils.py:17' in output_text
+
+    def test_reporter_omits_survivors_section_when_none(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED) for _ in range(5)]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'Top surviving gremlins:' not in output_text
+
+    def test_reporter_writes_footer(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        # Should have border at top and bottom
+        assert output_text.count('=') >= 40  # Multiple = signs for borders
+
+
+class TestConsoleReporterFormatting:
+    """Tests for console reporter formatting details."""
+
+    def test_formats_percentage_with_rounding(self, make_result):
+        # Create 3 results: 2 zapped, 1 survived = 66.67%
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        # Should round to whole number or one decimal
+        assert '67%' in output_text or '66.7%' in output_text or '66%' in output_text
+
+    def test_handles_zero_results_gracefully(self):
+        score = MutationScore.from_results([])
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert 'No gremlins tested' in output_text or '0 gremlins' in output_text
+
+    def test_includes_hint_for_detailed_report(self, make_result):
+        results = [make_result(GremlinResultStatus.SURVIVED)]
+        score = MutationScore.from_results(results)
+        output = StringIO()
+        reporter = ConsoleReporter(output=output)
+
+        reporter.write_report(score)
+
+        output_text = output.getvalue()
+        assert '--gremlin-report=html' in output_text or 'html' in output_text.lower()

--- a/tests/small/reporting/test_html.py
+++ b/tests/small/reporting/test_html.py
@@ -1,0 +1,195 @@
+"""Tests for the HTML reporter."""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_gremlins.instrumentation.gremlin import Gremlin
+from pytest_gremlins.reporting.html import HtmlReporter
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+from pytest_gremlins.reporting.score import MutationScore
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def make_gremlin():
+    """Factory fixture for creating test gremlins."""
+    counter = 0
+
+    def _make_gremlin(
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+    ) -> Gremlin:
+        nonlocal counter
+        counter += 1
+        return Gremlin(
+            gremlin_id=f'g{counter:03d}',
+            file_path=file_path,
+            line_number=line_number,
+            original_node=ast.parse('x >= 0', mode='eval').body,
+            mutated_node=ast.parse('x > 0', mode='eval').body,
+            operator_name=operator_name,
+            description=description,
+        )
+
+    return _make_gremlin
+
+
+@pytest.fixture
+def make_result(make_gremlin):
+    """Factory fixture for creating test results."""
+
+    def _make_result(
+        status: GremlinResultStatus = GremlinResultStatus.ZAPPED,
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+    ) -> GremlinResult:
+        gremlin = make_gremlin(
+            file_path=file_path,
+            line_number=line_number,
+            operator_name=operator_name,
+            description=description,
+        )
+        return GremlinResult(gremlin=gremlin, status=status)
+
+    return _make_result
+
+
+class TestHtmlReporterBasicStructure:
+    """Tests for basic HTML structure."""
+
+    def test_produces_valid_html(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '<!DOCTYPE html>' in html
+        assert '<html' in html
+        assert '</html>' in html
+
+    def test_includes_head_section(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '<head>' in html
+        assert '</head>' in html
+        assert '<title>' in html
+
+    def test_includes_body_section(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '<body>' in html
+        assert '</body>' in html
+
+
+class TestHtmlReporterContent:
+    """Tests for HTML content."""
+
+    def test_includes_title(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert 'pytest-gremlins' in html.lower() or 'mutation' in html.lower()
+
+    def test_includes_summary_stats(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '50' in html  # 50% score
+        assert 'zapped' in html.lower() or '1' in html
+
+    def test_includes_results_table(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py', line_number=42),
+            make_result(GremlinResultStatus.SURVIVED, file_path='utils.py', line_number=17),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert 'auth.py' in html
+        assert 'utils.py' in html
+        assert '42' in html
+        assert '17' in html
+
+    def test_highlights_survived_gremlins(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        # Should have some visual distinction for survived
+        assert 'survived' in html.lower()
+
+
+class TestHtmlReporterFileOutput:
+    """Tests for writing HTML to file."""
+
+    def test_writes_to_file(self, make_result, tmp_path: Path):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+        output_file = tmp_path / 'report.html'
+
+        reporter.write_report(score, output_file)
+
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert '<!DOCTYPE html>' in content
+
+    def test_includes_styles(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        # Should have embedded CSS for standalone report
+        assert '<style>' in html or 'style=' in html
+
+
+class TestHtmlReporterEmpty:
+    """Tests for handling empty results."""
+
+    def test_handles_empty_results(self):
+        score = MutationScore.from_results([])
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '<!DOCTYPE html>' in html
+        # Should indicate no results rather than crash
+        assert 'no' in html.lower() or '0' in html

--- a/tests/small/reporting/test_json.py
+++ b/tests/small/reporting/test_json.py
@@ -1,0 +1,248 @@
+"""Tests for the JSON reporter."""
+
+from __future__ import annotations
+
+import ast
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_gremlins.instrumentation.gremlin import Gremlin
+from pytest_gremlins.reporting.json_reporter import JsonReporter
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+from pytest_gremlins.reporting.score import MutationScore
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def make_gremlin():
+    """Factory fixture for creating test gremlins."""
+    counter = 0
+
+    def _make_gremlin(
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+    ) -> Gremlin:
+        nonlocal counter
+        counter += 1
+        return Gremlin(
+            gremlin_id=f'g{counter:03d}',
+            file_path=file_path,
+            line_number=line_number,
+            original_node=ast.parse('x >= 0', mode='eval').body,
+            mutated_node=ast.parse('x > 0', mode='eval').body,
+            operator_name=operator_name,
+            description=description,
+        )
+
+    return _make_gremlin
+
+
+@pytest.fixture
+def make_result(make_gremlin):
+    """Factory fixture for creating test results."""
+
+    def _make_result(
+        status: GremlinResultStatus = GremlinResultStatus.ZAPPED,
+        file_path: str = 'test.py',
+        line_number: int = 1,
+        operator_name: str = 'comparison',
+        description: str = '>= to >',
+        killing_test: str | None = None,
+    ) -> GremlinResult:
+        gremlin = make_gremlin(
+            file_path=file_path,
+            line_number=line_number,
+            operator_name=operator_name,
+            description=description,
+        )
+        return GremlinResult(gremlin=gremlin, status=status, killing_test=killing_test)
+
+    return _make_result
+
+
+class TestJsonReporterOutput:
+    """Tests for JSON reporter structure."""
+
+    def test_produces_valid_json(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        json_str = reporter.to_json(score)
+
+        # Should not raise
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+    def test_includes_summary_section(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert 'summary' in data
+        assert data['summary']['total'] == 2
+        assert data['summary']['zapped'] == 1
+        assert data['summary']['survived'] == 1
+
+    def test_includes_percentage_in_summary(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert 'percentage' in data['summary']
+        assert data['summary']['percentage'] == 50.0
+
+    def test_includes_results_array(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert 'results' in data
+        assert len(data['results']) == 2
+
+
+class TestJsonReporterResultFormat:
+    """Tests for individual result format in JSON."""
+
+    def test_result_includes_gremlin_id(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert data['results'][0]['gremlin_id'] == 'g001'
+
+    def test_result_includes_file_and_line(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED, file_path='src/auth.py', line_number=42)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert data['results'][0]['file_path'] == 'src/auth.py'
+        assert data['results'][0]['line_number'] == 42
+
+    def test_result_includes_status(self, make_result):
+        results = [make_result(GremlinResultStatus.SURVIVED)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert data['results'][0]['status'] == 'survived'
+
+    def test_result_includes_operator_and_description(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.ZAPPED,
+                operator_name='boundary',
+                description='>= 18 to >= 19',
+            )
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert data['results'][0]['operator'] == 'boundary'
+        assert data['results'][0]['description'] == '>= 18 to >= 19'
+
+    def test_result_includes_killing_test_when_present(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.ZAPPED,
+                killing_test='test_age_validation',
+            )
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert data['results'][0]['killing_test'] == 'test_age_validation'
+
+
+class TestJsonReporterFileOutput:
+    """Tests for writing JSON to file."""
+
+    def test_writes_to_file(self, make_result, tmp_path: Path):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+        output_file = tmp_path / 'report.json'
+
+        reporter.write_report(score, output_file)
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert 'summary' in data
+
+    def test_writes_formatted_json(self, make_result, tmp_path: Path):
+        results = [make_result(GremlinResultStatus.ZAPPED)]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+        output_file = tmp_path / 'report.json'
+
+        reporter.write_report(score, output_file)
+
+        content = output_file.read_text()
+        # Pretty-printed JSON has newlines
+        assert '\n' in content
+
+
+class TestJsonReporterFileBreakdown:
+    """Tests for per-file breakdown in JSON."""
+
+    def test_includes_files_section(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.SURVIVED, file_path='utils.py'),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        assert 'files' in data
+        assert 'auth.py' in data['files']
+        assert 'utils.py' in data['files']
+
+    def test_file_breakdown_includes_per_file_stats(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.SURVIVED, file_path='auth.py'),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = JsonReporter()
+
+        data = json.loads(reporter.to_json(score))
+
+        auth_stats = data['files']['auth.py']
+        assert auth_stats['total'] == 3
+        assert auth_stats['zapped'] == 2
+        assert auth_stats['survived'] == 1
+        assert auth_stats['percentage'] == pytest.approx(66.67, rel=0.01)

--- a/tests/small/reporting/test_results.py
+++ b/tests/small/reporting/test_results.py
@@ -1,0 +1,127 @@
+"""Tests for GremlinResult dataclass that tracks mutation test outcomes."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from pytest_gremlins.instrumentation.gremlin import Gremlin
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+
+
+class TestGremlinResultStatus:
+    """Tests for GremlinResultStatus enum."""
+
+    def test_status_has_zapped_value(self):
+        assert GremlinResultStatus.ZAPPED.value == 'zapped'
+
+    def test_status_has_survived_value(self):
+        assert GremlinResultStatus.SURVIVED.value == 'survived'
+
+    def test_status_has_timeout_value(self):
+        assert GremlinResultStatus.TIMEOUT.value == 'timeout'
+
+    def test_status_has_error_value(self):
+        assert GremlinResultStatus.ERROR.value == 'error'
+
+
+@pytest.fixture
+def sample_gremlin():
+    return Gremlin(
+        gremlin_id='g001',
+        file_path='src/auth.py',
+        line_number=42,
+        original_node=ast.parse('age >= 18', mode='eval').body,
+        mutated_node=ast.parse('age > 18', mode='eval').body,
+        operator_name='comparison',
+        description='>= to >',
+    )
+
+
+class TestGremlinResultCreation:
+    """Tests for GremlinResult dataclass creation and attributes."""
+
+    def test_result_stores_gremlin(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+        )
+        assert result.gremlin == sample_gremlin
+
+    def test_result_stores_status(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.SURVIVED,
+        )
+        assert result.status == GremlinResultStatus.SURVIVED
+
+    def test_result_stores_killing_test_when_zapped(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+            killing_test='test_age_boundary',
+        )
+        assert result.killing_test == 'test_age_boundary'
+
+    def test_result_killing_test_defaults_to_none(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.SURVIVED,
+        )
+        assert result.killing_test is None
+
+    def test_result_stores_execution_time(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+            execution_time_ms=42.5,
+        )
+        assert result.execution_time_ms == 42.5
+
+    def test_result_execution_time_defaults_to_none(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+        )
+        assert result.execution_time_ms is None
+
+    def test_result_is_immutable(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+        )
+        with pytest.raises(AttributeError):
+            result.status = GremlinResultStatus.SURVIVED
+
+
+class TestGremlinResultProperties:
+    """Tests for computed properties on GremlinResult."""
+
+    def test_is_zapped_returns_true_when_zapped(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+        )
+        assert result.is_zapped is True
+
+    def test_is_zapped_returns_false_when_survived(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.SURVIVED,
+        )
+        assert result.is_zapped is False
+
+    def test_is_survived_returns_true_when_survived(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.SURVIVED,
+        )
+        assert result.is_survived is True
+
+    def test_is_survived_returns_false_when_zapped(self, sample_gremlin):
+        result = GremlinResult(
+            gremlin=sample_gremlin,
+            status=GremlinResultStatus.ZAPPED,
+        )
+        assert result.is_survived is False

--- a/tests/small/reporting/test_score.py
+++ b/tests/small/reporting/test_score.py
@@ -1,0 +1,185 @@
+"""Tests for mutation score calculation."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from pytest_gremlins.instrumentation.gremlin import Gremlin
+from pytest_gremlins.reporting.results import GremlinResult, GremlinResultStatus
+from pytest_gremlins.reporting.score import MutationScore
+
+
+@pytest.fixture
+def make_gremlin():
+    """Factory fixture for creating test gremlins."""
+    counter = 0
+
+    def _make_gremlin(file_path: str = 'test.py', line_number: int = 1) -> Gremlin:
+        nonlocal counter
+        counter += 1
+        return Gremlin(
+            gremlin_id=f'g{counter:03d}',
+            file_path=file_path,
+            line_number=line_number,
+            original_node=ast.parse('x >= 0', mode='eval').body,
+            mutated_node=ast.parse('x > 0', mode='eval').body,
+            operator_name='comparison',
+            description='>= to >',
+        )
+
+    return _make_gremlin
+
+
+@pytest.fixture
+def make_result(make_gremlin):
+    """Factory fixture for creating test results."""
+
+    def _make_result(
+        status: GremlinResultStatus = GremlinResultStatus.ZAPPED,
+        file_path: str = 'test.py',
+        line_number: int = 1,
+    ) -> GremlinResult:
+        gremlin = make_gremlin(file_path=file_path, line_number=line_number)
+        return GremlinResult(gremlin=gremlin, status=status)
+
+    return _make_result
+
+
+class TestMutationScore:
+    """Tests for MutationScore dataclass."""
+
+    def test_score_stores_total(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED) for _ in range(10)]
+        score = MutationScore.from_results(results)
+        assert score.total == 10
+
+    def test_score_stores_zapped_count(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        assert score.zapped == 2
+
+    def test_score_stores_survived_count(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        assert score.survived == 2
+
+    def test_score_stores_timeout_count(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.TIMEOUT),
+            make_result(GremlinResultStatus.TIMEOUT),
+        ]
+        score = MutationScore.from_results(results)
+        assert score.timeout == 2
+
+    def test_score_stores_error_count(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ERROR),
+        ]
+        score = MutationScore.from_results(results)
+        assert score.error == 1
+
+
+class TestMutationScorePercentage:
+    """Tests for mutation score percentage calculation."""
+
+    def test_percentage_when_all_zapped(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED) for _ in range(10)]
+        score = MutationScore.from_results(results)
+        assert score.percentage == 100.0
+
+    def test_percentage_when_none_zapped(self, make_result):
+        results = [make_result(GremlinResultStatus.SURVIVED) for _ in range(10)]
+        score = MutationScore.from_results(results)
+        assert score.percentage == 0.0
+
+    def test_percentage_with_mixed_results(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.ZAPPED),  # 9 zapped
+            make_result(GremlinResultStatus.SURVIVED),  # 1 survived
+        ]
+        score = MutationScore.from_results(results)
+        assert score.percentage == 90.0
+
+    def test_percentage_with_no_results(self):
+        score = MutationScore.from_results([])
+        assert score.percentage == 0.0
+
+    def test_percentage_treats_timeout_as_zapped(self, make_result):
+        """Timeouts count as zapped for score calculation (test caught something)."""
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.TIMEOUT),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        # 2 out of 3 (zapped + timeout) = 66.67%
+        assert score.percentage == pytest.approx(66.67, rel=0.01)
+
+
+class TestMutationScoreByFile:
+    """Tests for file-level score breakdown."""
+
+    def test_by_file_returns_dict_keyed_by_file_path(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.SURVIVED, file_path='utils.py'),
+        ]
+        score = MutationScore.from_results(results)
+        file_scores = score.by_file()
+        assert set(file_scores.keys()) == {'auth.py', 'utils.py'}
+
+    def test_by_file_calculates_per_file_score(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.ZAPPED, file_path='auth.py'),
+            make_result(GremlinResultStatus.SURVIVED, file_path='utils.py'),
+        ]
+        score = MutationScore.from_results(results)
+        file_scores = score.by_file()
+        assert file_scores['auth.py'].percentage == 100.0
+        assert file_scores['utils.py'].percentage == 0.0
+
+
+class TestMutationScoreTopSurvivors:
+    """Tests for getting top surviving gremlins."""
+
+    def test_top_survivors_returns_survived_results(self, make_result):
+        results = [
+            make_result(GremlinResultStatus.ZAPPED),
+            make_result(GremlinResultStatus.SURVIVED),
+            make_result(GremlinResultStatus.SURVIVED),
+        ]
+        score = MutationScore.from_results(results)
+        survivors = score.top_survivors()
+        assert len(survivors) == 2
+        assert all(r.is_survived for r in survivors)
+
+    def test_top_survivors_limits_results(self, make_result):
+        results = [make_result(GremlinResultStatus.SURVIVED) for _ in range(10)]
+        score = MutationScore.from_results(results)
+        survivors = score.top_survivors(limit=3)
+        assert len(survivors) == 3
+
+    def test_top_survivors_returns_empty_when_none_survived(self, make_result):
+        results = [make_result(GremlinResultStatus.ZAPPED) for _ in range(5)]
+        score = MutationScore.from_results(results)
+        survivors = score.top_survivors()
+        assert len(survivors) == 0


### PR DESCRIPTION
## Summary

- Adds `GremlinResult` dataclass to track individual mutation test outcomes (zapped/survived/timeout/error)
- Implements `MutationScore` to aggregate results with percentage calculation and file-level breakdown
- Creates `ConsoleReporter` for human-readable terminal output with summary and top survivors
- Adds `JsonReporter` for machine-readable JSON output (CI integration)
- Implements `HtmlReporter` for standalone HTML reports with embedded CSS

## Test plan

- [x] All 207 tests pass (62 new tests added for reporting module)
- [x] Type checking passes (mypy strict mode)
- [x] Linting passes (ruff)
- [x] Formatting validated (ruff format)
- [ ] Manual verification of console output format
- [ ] Manual verification of HTML report appearance

## Related Issues

Closes #6

## Example Console Output

```
================== pytest-gremlins mutation report ==================

Zapped: 142 gremlins (89%)
Survived: 18 gremlins (11%)

Top surviving gremlins:
  src/auth.py:42          >= to >          (comparison)
  src/utils.py:17         + to -           (arithmetic)

Run with --gremlin-report=html for detailed report.
======================================================================
```