### PR TITLE
fix(ci): use block scalar to avoid YAML parsing error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,8 @@ jobs:
             pytest-gremlins
 
       - name: Verify import
-        run: python -c "import pytest_gremlins; print(f'Version: {pytest_gremlins.__version__}')"
+        run: |
+          python -c "import pytest_gremlins; print(f'Version: {pytest_gremlins.__version__}')"
 
   # Publish to Production PyPI
   publish-pypi:


### PR DESCRIPTION
## Summary

- Fixed YAML parsing error in release workflow caused by Python f-string curly braces being interpreted as YAML mapping
- Changed from inline `run:` to block scalar `run: |` format

## Test plan

- [x] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
- [ ] CI passes (will verify in PR)
- [ ] Release workflow no longer fails on non-tag pushes

Fixes #18