### PR TITLE
ci: add dogfood workflow for self-mutation testing

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -72,7 +72,7 @@ jobs:
               ;;
             coverage)
               echo "path=src/pytest_gremlins/coverage" >> $GITHUB_OUTPUT
-              echo "tests=tests/small/coverage" >> $GITHUB_OUTPUT
+              echo "tests=tests/small/coverage_module" >> $GITHUB_OUTPUT
               ;;
             operators)
               echo "path=src/pytest_gremlins/operators" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` workflow that allows running pytest-gremlins on its own codebase. This serves as:

1. **Proof that it works** - We eat our own dog food
2. **Validation of our own test quality** - Our mutation score demonstrates test effectiveness
3. **Real-world example** - Shows the plugin in action on a real codebase

## Local Testing Results

Tested locally on various modules:

### Hasher Module (4 gremlins)
```
Zapped: 4 gremlins (100%)
Survived: 0 gremlins (0%)
```

### Reporting Module (52 gremlins)
```
pytest-gremlins: Starting parallel execution with auto workers
pytest-gremlins: Progress 52/52

Zapped: 52 gremlins (100%)
Survived: 0 gremlins (0%)
```

### Full Codebase Stats
- **525+ gremlins** across src/pytest_gremlins
- **Coverage-guided test selection** reduces test runs by 10-100x
- **Parallel execution** completes module-level dogfood in ~12 seconds

## Workflow Features

The dogfood workflow supports:

| Input | Options | Default |
|-------|---------|---------|
| `target_module` | reporting, cache, coverage, operators, instrumentation, parallel, all | reporting |
| `execution_mode` | sequential, parallel, batch | parallel |

Usage:
1. Go to Actions tab
2. Select "Dogfood" workflow
3. Click "Run workflow"
4. Select target module and execution mode
5. Download HTML report from artifacts

## Acceptance Criteria

- [x] pytest-gremlins can run on `src/pytest_gremlins/`
- [x] Create a `workflow_dispatch` workflow for dogfooding
- [x] Document results in PR description
- [x] Note any survivors found (none so far - 100% kill rate on tested modules)

Closes #85