### PR TITLE
fix: prevent pytest-cov from hijacking coverage subprocess

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -580,7 +580,7 @@ def _make_node_ids_relative(node_ids: list[str], rootdir: Path) -> list[str]:
     Returns:
         List of node IDs with paths made relative to rootdir.
     """
-    import re
+    import re  # noqa: PLC0415
 
     result = []
     for node_id in node_ids:
@@ -807,7 +807,7 @@ def _run_batch_mutation_testing(  # pragma: no cover  # noqa: C901
     Returns:
         List of results for each gremlin.
     """
-    from pytest_gremlins.parallel.batch_executor import BatchExecutor
+    from pytest_gremlins.parallel.batch_executor import BatchExecutor  # noqa: PLC0415
 
     rootdir = Path(session.config.rootdir)  # type: ignore[attr-defined]
     base_test_command = _build_test_command(gremlin_session.instrumented_dir)
@@ -929,7 +929,7 @@ def _run_parallel_mutation_testing(  # pragma: no cover  # noqa: C901
     Returns:
         List of results for each gremlin.
     """
-    from concurrent.futures import as_completed
+    from concurrent.futures import as_completed  # noqa: PLC0415
 
     rootdir = Path(session.config.rootdir)  # type: ignore[attr-defined]
     base_test_command = _build_test_command(gremlin_session.instrumented_dir)

--- a/tests/small/test_plugin_pytest_cov_conflict.py
+++ b/tests/small/test_plugin_pytest_cov_conflict.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.small()
+@pytest.mark.small
 class TestCoverageSubprocessClearsAddopts:
     """Verify the coverage subprocess includes -o addopts= to clear user config."""
 
@@ -73,7 +73,7 @@ class TestCoverageSubprocessClearsAddopts:
             assert addopts_idx < pos
 
 
-@pytest.mark.small()
+@pytest.mark.small
 class TestEmptyCoverageWarning:
     """Verify a warning is emitted when coverage collection returns empty data."""
 


### PR DESCRIPTION
## Summary
- Clear pytest `addopts` in coverage subprocess to prevent pytest-cov from interfering with gremlins' coverage collection
- Add warning when coverage collection returns empty data to help users diagnose issues
- Add `-o addopts=` to the subprocess command so user-configured `--cov` flags don't take over

## Root Cause
When `--cov` is in pytest's `addopts`, pytest-cov loads inside the `coverage run -m pytest` subprocess and takes over coverage measurement. The outer coverage.py wrapper collects zero data, resulting in 0% kill rate.

Closes #113

## Test plan
- [x] Unit test verifying subprocess command includes addopts override
- [x] Unit test verifying addopts override appears before test node IDs
- [x] Unit test verifying warning on empty coverage data
- [x] Unit test verifying no warning when coverage data is present
- [x] All existing tests still pass (548 passed)
- [x] Lint, format, type check all pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)