### PR TITLE
fix: commit .secrets.baseline to fix pre-commit hook blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,6 @@ Thumbs.db
 # Project specific
 .gremlins/
 *.db
-.secrets.baseline
 *.pstats
 mutants/
 .mutmut-cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,6 @@ repos:
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline]
-        exclude: package.lock.json
 
   # Validate pyproject.toml
   - repo: https://github.com/abravalheri/validate-pyproject

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,159 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "docs/cookbook/django.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/django.md",
+        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "is_verified": false,
+        "line_number": 188
+      }
+    ],
+    "docs/cookbook/fastapi.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/fastapi.md",
+        "hashed_secret": "4255bcff9f91b6d5d24716aac695f9b7155dd8ef",
+        "is_verified": false,
+        "line_number": 211
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/fastapi.md",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 262
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/fastapi.md",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
+        "is_verified": false,
+        "line_number": 297
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/fastapi.md",
+        "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
+        "is_verified": false,
+        "line_number": 377
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/cookbook/fastapi.md",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 516
+      }
+    ]
+  },
+  "generated_at": "2026-02-16T05:41:57Z"
+}


### PR DESCRIPTION
## Summary

Fixes #117 - Pre-commit hooks were blocking all commits because `.secrets.baseline` was gitignored.

## Changes

- **Remove `.secrets.baseline` from `.gitignore`**: This file catalogs known false positives and must be committed so fresh clones have it
- **Remove incorrect `exclude: package.lock.json`**: This was a typo (should be `package-lock.json`) and is irrelevant to a Python project
- **Generate `.secrets.baseline`**: Created the baseline file with `detect-secrets scan`

## Verification

- ✅ `uv run pre-commit run detect-secrets --all-files` passes
- ✅ All pre-commit hooks pass on commit
- ✅ Fresh clones will now have the baseline file

## Test Plan

- [x] Generate `.secrets.baseline` with `detect-secrets scan`
- [x] Verify `detect-secrets` hook passes with baseline
- [x] Verify all pre-commit hooks pass
- [x] Commit changes successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)