### PR TITLE
fix: suppress addopts and coverage in mutation subprocesses

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1362,6 +1362,9 @@ def _build_test_command(instrumented_dir: Path | None) -> list[str]:
             '-x',
             '--tb=no',
             '-q',
+            '-o',
+            'addopts=',
+            '--no-cov',
         ]
     return [
         sys.executable,
@@ -1370,6 +1373,9 @@ def _build_test_command(instrumented_dir: Path | None) -> list[str]:
         '-x',
         '--tb=no',
         '-q',
+        '-o',
+        'addopts=',
+        '--no-cov',
     ]
 
 

--- a/tests/small/test_plugin_helpers.py
+++ b/tests/small/test_plugin_helpers.py
@@ -208,3 +208,35 @@ class TestBuildTestCommand:
         assert 'pytest' in result
         assert '-x' in result
         assert '--tb=no' in result
+
+    def test_with_instrumented_dir_suppresses_addopts(self, tmp_path: Path) -> None:
+        """When instrumented_dir provided, resets addopts to prevent inherited flags."""
+        instrumented_dir = tmp_path / 'instrumented'
+        instrumented_dir.mkdir()
+
+        result = _build_test_command(instrumented_dir)
+
+        assert '-o' in result
+        assert 'addopts=' in result
+
+    def test_without_instrumented_dir_suppresses_addopts(self) -> None:
+        """When instrumented_dir is None, resets addopts to prevent inherited flags."""
+        result = _build_test_command(None)
+
+        assert '-o' in result
+        assert 'addopts=' in result
+
+    def test_with_instrumented_dir_disables_coverage(self, tmp_path: Path) -> None:
+        """When instrumented_dir provided, disables coverage to avoid exit code 2."""
+        instrumented_dir = tmp_path / 'instrumented'
+        instrumented_dir.mkdir()
+
+        result = _build_test_command(instrumented_dir)
+
+        assert '--no-cov' in result
+
+    def test_without_instrumented_dir_disables_coverage(self) -> None:
+        """When instrumented_dir is None, disables coverage to avoid exit code 2."""
+        result = _build_test_command(None)
+
+        assert '--no-cov' in result


### PR DESCRIPTION
Fixes #129

## Problem

Projects with `--cov-fail-under=100` (or other coverage flags) in their `addopts`
saw ~79% ERROR rates when running mutation testing. This was reported by a user
running pytest-gremlins against a project with 100% coverage enforcement.

**Root cause:** Mutation subprocesses inherit `addopts` from the project's
`pyproject.toml`. Each subprocess only runs the tests that cover the specific
mutated line — not the full suite. This means coverage is always below the
project's threshold, causing pytest to exit with code 2 instead of 0 or 1.
pytest-gremlins only interprets exit code 0 (SURVIVED) and 1 (ZAPPED) — anything
else is classified as ERROR.

## Fix

Pass `-o addopts=` and `--no-cov` in `_build_test_command` for both execution
paths (bootstrap script and direct pytest). This resets inherited configuration
and disables coverage collection in mutation subprocesses where it is both
incorrect and unnecessary.

## Tests

Four new tests added to `TestBuildTestCommand` following TDD (red → green):

- `test_with_instrumented_dir_suppresses_addopts`
- `test_without_instrumented_dir_suppresses_addopts`
- `test_with_instrumented_dir_disables_coverage`
- `test_without_instrumented_dir_disables_coverage`

## Checklist

- [x] Failing tests written first
- [x] Implementation makes tests pass
- [x] Small + medium suite passing (696 passed)
- [x] ruff, mypy, bandit clean

Generated with [Claude Code](https://claude.ai/claude-code)