### PR TITLE
bump: version 1.2.0 → 1.3.0b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v1.3.0b0 (2026-02-20)
 
 ### Feat
 
-- integrate with pytest-xdist `-n` flag for parallel mutation execution (#130)
+- integrate pytest-xdist -n flag for parallel mutation execution (#130) (#175)
 
 ### Fix
 
-- suppress `addopts` and `--cov` in mutation subprocesses to prevent exit-code misclassification (#129)
-
-### Deprecated
-
-- `--gremlin-parallel` and `--gremlin-workers` — use `-n` (pytest-xdist) instead
+- suppress addopts and coverage in mutation subprocesses (#128)
 
 ## v1.2.0 (2026-02-15)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-gremlins"
-version = "1.2.0"
+version = "1.3.0b0"
 description = "Fast-first mutation testing for pytest. Let the gremlins loose, see which ones survive."
 readme = "README.md"
 license = { text = "MIT" }
@@ -340,7 +340,7 @@ directory = "htmlcov"
 # =============================================================================
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.2.0"
+version = "1.3.0b0"
 version_files = [
     "pyproject.toml:version",
     "src/pytest_gremlins/__init__.py:__version__",

--- a/src/pytest_gremlins/__init__.py
+++ b/src/pytest_gremlins/__init__.py
@@ -25,5 +25,5 @@ For more information, see https://pytest-gremlins.readthedocs.io
 from __future__ import annotations
 
 
-__version__ = '1.2.0'
+__version__ = '1.3.0b0'
 __all__ = ['__version__']

--- a/uv.lock
+++ b/uv.lock
@@ -1343,7 +1343,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.2.0"
+version = "1.3.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

- Bumps version to `1.3.0b0` (beta prerelease)
- Includes CHANGELOG entries for feat #130 (xdist -n integration) and fix #128 (suppress addopts)
- Tag `v1.3.0b0` pushed separately to trigger the release pipeline

## Release pipeline

The `v1.3.0b0` tag is already live and the Release workflow is running. This PR merges the version bump commit back to main.

Generated with [Claude Code](https://claude.ai/claude-code)