### PR TITLE
fix: use Path for sources.json in WorkerPool to fix Windows path separators

### DIFF
--- a/src/pytest_gremlins/parallel/pool.py
+++ b/src/pytest_gremlins/parallel/pool.py
@@ -18,6 +18,7 @@ from concurrent.futures import (
 from dataclasses import dataclass
 import logging
 import os
+from pathlib import Path
 import subprocess
 import time
 from typing import Self
@@ -229,7 +230,7 @@ class WorkerPool:
         # Add instrumented dir to env vars if provided
         all_env_vars = dict(env_vars)
         if instrumented_dir is not None:
-            all_env_vars['PYTEST_GREMLINS_SOURCES_FILE'] = f'{instrumented_dir}/sources.json'
+            all_env_vars['PYTEST_GREMLINS_SOURCES_FILE'] = str(Path(instrumented_dir) / 'sources.json')
 
         return self._executor.submit(
             _run_gremlin_test,


### PR DESCRIPTION
## Summary

- `WorkerPool.submit()` was building the `PYTEST_GREMLINS_SOURCES_FILE` env var path using an f-string with a hardcoded `/` separator: `f'{instrumented_dir}/sources.json'`
- On Windows this produced mixed separators (e.g. `C:\path/sources.json`), causing subprocess env var comparisons to fail
- Fixed by using `Path(instrumented_dir) / 'sources.json'` which produces correct native paths on all platforms

Caught by `test_instrumented_dir_sets_sources_env_var` failing on Windows Python 3.12 in the release workflow.

## Test plan

- [x] `TestWorkerPoolExecution::test_instrumented_dir_sets_sources_env_var` passes (pre-existing test covers both the `None` and non-`None` paths)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)