### PR TITLE
docs: consolidate v1.3.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,46 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.3.0b5 (2026-02-21)
+## v1.3.0 (2026-02-21)
 
-### Fix
+### Added
 
-- --gremlin-workers=N implies parallel mode without --gremlin-parallel (#188)
+- `--gremlin-workers=N` now implies `--gremlin-parallel` — specifying a worker count
+  automatically enables parallel mode. Use `pytest --gremlins --gremlin-workers=auto`
+  without needing to also pass `--gremlin-parallel`. (#188)
 
-## v1.3.0b4 (2026-02-21)
+### Fixed
 
-### Fix
-
-- measure coverage on small+medium only in release workflow
-
-## v1.3.0b3 (2026-02-21)
-
-### Fix
-
-- **ci**: enable subprocess coverage tracking via sitecustomize.py (#186)
-
-## v1.3.0b2 (2026-02-21)
-
-### Fix
-
-- use Path for sources.json in WorkerPool to fix Windows path separators (#185)
-
-## v1.3.0b1 (2026-02-21)
-
-### Fix
-
-- make --cov + --gremlins produce real coverage output (#180) (#184)
-- revert xdist -n integration; error explicitly on --gremlins + -n conflict (#179) (#183)
-
-## v1.3.0b0 (2026-02-20)
-
-### Feat
-
-- integrate pytest-xdist -n flag for parallel mutation execution (#130) (#175)
-
-### Fix
-
-- suppress addopts and coverage in mutation subprocesses (#128)
+- `pytest --gremlins --cov` now produces real coverage output alongside mutation results.
+  Previously the mutation pre-scan subprocess corrupted the `.coverage` data. (#184)
+- Windows: Fixed path separator bug in `WorkerPool` sources.json that caused worker
+  failures on Windows. (#185)
+- Mutation subprocesses now suppress `addopts` and coverage instrumentation from the
+  host environment, preventing subprocess interference. (#128)
+- `pytest --gremlins -n N` (combining with pytest-xdist) now raises a clear error
+  instead of silently producing incorrect results. (#183)
 
 ## v1.2.0 (2026-02-15)
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ pytest-gremlins is fast because of *how* it works, not just parallelization:
 
 Benchmarked against [mutmut](https://github.com/boxed/mutmut) on a synthetic project:
 
-| Mode                                            | Time   | vs mutmut | Speedup           |
-| ----------------------------------------------- | ------ | --------- | ----------------- |
-| `--gremlins` (sequential)                       | 17.79s | 14.90s    | 0.84x (see note)  |
-| `--gremlins --gremlin-parallel`                 | 3.99s  | 14.90s    | **3.73x faster**  |
-| `--gremlins --gremlin-parallel --gremlin-cache` | 1.08s  | 14.90s    | **13.82x faster** |
+| Mode                                                 | Time   | vs mutmut | Speedup           |
+| ---------------------------------------------------- | ------ | --------- | ----------------- |
+| `--gremlins` (sequential)                            | 17.79s | 14.90s    | 0.84x (see note)  |
+| `--gremlins --gremlin-workers=auto`                  | 3.99s  | 14.90s    | **3.73x faster**  |
+| `--gremlins --gremlin-workers=auto --gremlin-cache`  | 1.08s  | 14.90s    | **13.82x faster** |
 
 **Key findings:**
 

--- a/docs/architecture/parallelization.md
+++ b/docs/architecture/parallelization.md
@@ -213,11 +213,11 @@ def worker_main(mutations: list[str], result_queue: Queue):
 
 ### Number of Workers
 
-Use xdist's `-n` flag (requires `pytest-xdist`):
+Use `--gremlin-workers` to set the worker count. Specifying workers automatically enables parallel mode:
 
 ```bash
-pytest --gremlins -n auto   # use all CPU cores
-pytest --gremlins -n 4      # use 4 workers
+pytest --gremlins --gremlin-workers=auto   # use all CPU cores
+pytest --gremlins --gremlin-workers=4      # use 4 workers
 ```
 
 ### Worker Timeout
@@ -316,17 +316,19 @@ def db_session():
     session.rollback()
 ```
 
-## pytest-xdist Integration
+## pytest-xdist Compatibility
 
-pytest-gremlins can integrate with pytest-xdist for existing parallel test setups:
+`--gremlins` and `-n` (pytest-xdist) cannot be combined — passing both raises an error.
+pytest-xdist distributes tests across workers, which conflicts with how pytest-gremlins
+controls mutation state per worker process.
+
+To parallelize mutation execution, use `--gremlin-workers`:
 
 ```bash
-# Use xdist for test parallelization within each gremlin worker
-pytest --gremlins --workers 4 -n 2
-# 4 gremlin workers, each running 2 test processes
+pytest --gremlins --gremlin-workers=auto
 ```
 
-This can help when individual tests are slow but parallelizable.
+This uses pytest-gremlins' own worker pool, which is built specifically for mutation isolation.
 
 ## Monitoring Parallel Execution
 
@@ -377,7 +379,7 @@ Parallelization efficiency: 96%
 When debugging, run with a single worker to get sequential output:
 
 ```bash
-pytest --gremlins -n 1
+pytest --gremlins --gremlin-workers=1
 ```
 
 ### Reproduce Specific Mutation

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -35,11 +35,10 @@ All command-line options are prefixed with `--gremlin` or `--gremlins`.
 |--------|------|---------|-------------|
 | `--gremlin-cache` | flag | `false` | Enable incremental analysis cache |
 | `--gremlin-clear-cache` | flag | `false` | Clear cache before running |
-| `-n auto` / `-n N` | xdist flag | — | Enable parallel execution (requires [pytest-xdist](https://pytest-xdist.readthedocs.io/)) |
+| `--gremlin-parallel` | flag | `false` | Enable parallel mutation execution |
+| `--gremlin-workers` | integer | CPU count | Number of parallel workers (implies `--gremlin-parallel`) |
 | `--gremlin-batch` | flag | `false` | Enable batch execution mode |
 | `--gremlin-batch-size` | integer | `10` | Number of gremlins per batch |
-| `--gremlin-parallel` | flag | `false` | *Deprecated* — use `-n` (pytest-xdist) instead |
-| `--gremlin-workers` | integer | CPU count | *Deprecated* — use `-n` (pytest-xdist) instead |
 
 ### Usage Examples
 
@@ -85,16 +84,16 @@ pytest --gremlins --gremlin-cache
 pytest --gremlins --gremlin-cache --gremlin-clear-cache
 ```
 
-**Enable parallel execution (requires pytest-xdist):**
+**Enable parallel execution:**
 
 ```bash
-pytest --gremlins -n auto
+pytest --gremlins --gremlin-workers=auto
 ```
 
 **Parallel with specific worker count:**
 
 ```bash
-pytest --gremlins -n 4
+pytest --gremlins --gremlin-workers=4
 ```
 
 **Enable batch mode for reduced overhead:**
@@ -110,7 +109,7 @@ pytest --gremlins \
     --gremlin-targets=src/core \
     --gremlin-operators=comparison,boundary \
     --gremlin-cache \
-    -n auto \
+    --gremlin-workers=auto \
     --gremlin-report=html
 ```
 
@@ -236,15 +235,19 @@ pytest --gremlins --gremlin-cache --gremlin-clear-cache
 
 ### Parallel Execution
 
-pytest-gremlins integrates with [pytest-xdist](https://pytest-xdist.readthedocs.io/) for parallel
-mutation testing. If xdist is installed, pass `-n` to control the worker count:
+Use `--gremlin-workers` to distribute mutations across multiple worker processes. Specifying a
+worker count automatically enables parallel mode — you do not need to also pass `--gremlin-parallel`:
 
 ```bash
-pytest --gremlins -n auto   # use all CPU cores
-pytest --gremlins -n 4      # use 4 workers
+pytest --gremlins --gremlin-workers=auto   # use all CPU cores
+pytest --gremlins --gremlin-workers=4      # use 4 workers
 ```
 
-`-n auto` detects CPU count at runtime. `-n 1` runs sequentially (useful for debugging).
+`--gremlin-workers=auto` detects CPU count at runtime. `--gremlin-workers=1` runs sequentially
+(useful for debugging).
+
+`--gremlins` and `-n` (pytest-xdist) cannot be combined — passing both raises an error. Use
+`--gremlin-workers` for parallel mutation execution.
 
 ### Batch Execution
 
@@ -269,7 +272,7 @@ For maximum speed, combine all performance options:
 ```bash
 pytest --gremlins \
     --gremlin-cache \
-    -n auto \
+    --gremlin-workers=auto \
     --gremlin-batch \
     --gremlin-batch-size=20
 ```
@@ -304,7 +307,7 @@ jobs:
         run: |
           uv run pytest --gremlins \
             --gremlin-cache \
-            -n auto \
+            --gremlin-workers=auto \
             --gremlin-report=json
 
       - name: Upload mutation report
@@ -321,7 +324,7 @@ mutation_testing:
   stage: test
   script:
     - pip install uv && uv sync
-    - uv run pytest --gremlins --gremlin-cache -n auto --gremlin-report=json
+    - uv run pytest --gremlins --gremlin-cache --gremlin-workers=auto --gremlin-report=json
   artifacts:
     reports:
       junit: gremlin-report.json
@@ -340,7 +343,7 @@ repos:
     hooks:
       - id: mutation-testing
         name: Mutation Testing
-        entry: pytest --gremlins --gremlin-cache -n auto
+        entry: pytest --gremlins --gremlin-cache --gremlin-workers=auto
         language: system
         pass_filenames: false
         stages: [pre-push]  # Run on push, not commit

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -320,7 +320,7 @@ Try these strategies:
 
 1. **Start small**: Target specific files with `--gremlin-targets`
 2. **Use incremental mode**: `--gremlin-cache` skips unchanged code
-3. **Enable parallel execution**: `--gremlin-parallel`
+3. **Enable parallel execution**: `--gremlin-workers=auto`
 4. **Focus operators**: `--gremlin-operators=comparison,boolean`
 5. **Run in CI only**: Skip mutation testing in local development
 
@@ -340,5 +340,5 @@ Now that you understand the basics:
 | Target specific files | `pytest --gremlins --gremlin-targets=src/mymodule.py` |
 | Generate HTML report | `pytest --gremlins --gremlin-report=html` |
 | Use caching | `pytest --gremlins --gremlin-cache` |
-| Parallel execution | `pytest --gremlins --gremlin-parallel` |
+| Parallel execution | `pytest --gremlins --gremlin-workers=auto` |
 | Use specific operators | `pytest --gremlins --gremlin-operators=comparison,boolean` |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -526,25 +526,40 @@ Coverage numbers are incorrect or missing when running mutation testing.
 
 **Symptom:**
 
-Mutation testing hangs or produces inconsistent results when using pytest-xdist.
+```text
+ERROR: --gremlins and -n cannot be used together. Use --gremlin-workers for parallel mutation execution.
+```
 
-**Cause:** pytest-xdist parallelizes test execution, which conflicts with pytest-gremlins' own parallelization strategy.
+**Cause:** `--gremlins` and `-n` (pytest-xdist) cannot be combined. pytest-xdist distributes
+tests across workers, which conflicts with how pytest-gremlins controls mutation state per
+worker process.
 
 **Solution:**
 
-1. Disable xdist when running mutation testing:
+Use `--gremlin-workers` instead:
 
-   ```bash
-   pytest --gremlins -p no:xdist
-   ```
+```bash
+pytest --gremlins --gremlin-workers=auto   # parallel across all CPU cores
+pytest --gremlins --gremlin-workers=4      # specific worker count
+```
 
-2. Use pytest-gremlins' built-in parallelization instead:
+**Prevention:** Never combine `--gremlins` with `-n`.
 
-   ```bash
-   pytest --gremlins --gremlin-parallel --gremlin-workers=4
-   ```
+---
 
-**Prevention:** Don't combine xdist with pytest-gremlins.
+### Can I use pytest --gremlins with -n (pytest-xdist)?
+
+No. pytest-gremlins does not support using `-n` (pytest-xdist) for parallel mutation execution.
+Passing both `--gremlins` and `-n` produces an explicit error.
+
+For parallel mutation testing, use `--gremlin-workers` instead:
+
+```bash
+pytest --gremlins --gremlin-workers=auto   # parallel across all CPU cores
+```
+
+`--gremlin-workers=N` uses pytest-gremlins' own worker pool. Each worker runs with a different
+`PYTEST_GREMLINS_ACTIVE` environment variable, so mutations never interfere with each other.
 
 ---
 


### PR DESCRIPTION
## Summary

- Consolidates all `v1.3.0b0`–`v1.3.0b5` CHANGELOG entries into a single clean `v1.3.0` section
- Fixes critical documentation inaccuracies: `--gremlin-parallel` and `--gremlin-workers` were incorrectly marked as deprecated in favor of `-n` (pytest-xdist), which is not supported
- Updates all user-facing docs to show `--gremlin-workers=auto` as the recommended parallel invocation (which now implies `--gremlin-parallel`)
- Adds troubleshooting guidance for the `-n` + `--gremlins` conflict

## Files changed

- `CHANGELOG.md` — consolidated beta entries into single v1.3.0 section
- `README.md` — updated performance table to show `--gremlin-workers=auto`
- `docs/guide/configuration.md` — removed incorrect "Deprecated" labels; replaced all `-n auto` examples with `--gremlin-workers=auto`; added clear note that `-n` is unsupported
- `docs/architecture/parallelization.md` — fixed worker config section; replaced incorrect xdist integration section with compatibility note
- `docs/guide/getting-started.md` — updated quick reference and FAQ to use `--gremlin-workers=auto`
- `docs/guide/troubleshooting.md` — added xdist conflict FAQ entry

Generated with [Claude Code](https://claude.ai/claude-code)