### PR TITLE
docs: fix remaining stale --gremlin-parallel references missed in #189

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -254,7 +254,7 @@ pytest-gremlins uses several optimizations:
 - **Coverage-guided selection**: Only runs tests that cover the mutated code
 - **Early exit**: Stops testing a gremlin as soon as one test fails
 - **Incremental caching**: Skips unchanged code on subsequent runs (use `--gremlin-cache`)
-- **Parallel execution**: Distributes gremlins across CPU cores (use `--gremlin-parallel`)
+- **Parallel execution**: Distributes gremlins across CPU cores (use `--gremlin-workers=auto`)
 
 For a first run, expect 10-100x the time of a normal test run. Subsequent cached runs are much faster.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -441,7 +441,7 @@ This indicates a bug in pytest-gremlins. Please:
 2. As a workaround, disable parallel execution:
 
    ```bash
-   pytest --gremlins  # without --gremlin-parallel
+   pytest --gremlins  # without --gremlin-workers
    ```
 
 ---
@@ -476,7 +476,7 @@ Use valid configuration values via CLI arguments:
 - `--gremlin-batch-size`: A positive integer (default: 10)
 
 ```bash
-pytest --gremlins --gremlin-parallel --gremlin-workers=4
+pytest --gremlins --gremlin-workers=4
 ```
 
 Note: `workers` and `timeout` are not configurable via `pyproject.toml`. Use CLI arguments instead.


### PR DESCRIPTION
## Summary

Fixes three spots in user-facing guides that still referenced `--gremlin-parallel` after #189 updated the rest of the docs to `--gremlin-workers=auto`.

- `docs/guide/getting-started.md` — FAQ bullet "How long does mutation testing take?"
- `docs/guide/troubleshooting.md` — two spots in the WorkerPool error and invalid pool configuration sections

Caught by post-merge review of #189.

## Related

- Closes no issue (missed spots from #189)
- See #190 for the related code bug (stale deprecation warning in `plugin.py`)

Generated with [Claude Code](https://claude.ai/claude-code)