### PR TITLE
fix(docs): replace --gremlin-workers=auto with --gremlin-parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Benchmarked against [mutmut](https://github.com/boxed/mutmut) on a synthetic pro
 | Mode                                                 | Time   | vs mutmut | Speedup           |
 | ---------------------------------------------------- | ------ | --------- | ----------------- |
 | `--gremlins` (sequential)                            | 17.79s | 14.90s    | 0.84x (see note)  |
-| `--gremlins --gremlin-workers=auto`                  | 3.99s  | 14.90s    | **3.73x faster**  |
-| `--gremlins --gremlin-workers=auto --gremlin-cache`  | 1.08s  | 14.90s    | **13.82x faster** |
+| `--gremlins --gremlin-parallel`                      | 3.99s  | 14.90s    | **3.73x faster**  |
+| `--gremlins --gremlin-parallel --gremlin-cache`      | 1.08s  | 14.90s    | **13.82x faster** |
 
 **Key findings:**
 

--- a/docs/architecture/parallelization.md
+++ b/docs/architecture/parallelization.md
@@ -213,11 +213,11 @@ def worker_main(mutations: list[str], result_queue: Queue):
 
 ### Number of Workers
 
-Use `--gremlin-workers` to set the worker count. Specifying workers automatically enables parallel mode:
+Use `--gremlin-parallel` to enable parallel mode. Pass `--gremlin-workers=N` to pin the worker count (implies `--gremlin-parallel`):
 
 ```bash
-pytest --gremlins --gremlin-workers=auto   # use all CPU cores
-pytest --gremlins --gremlin-workers=4      # use 4 workers
+pytest --gremlins --gremlin-parallel        # use all CPU cores
+pytest --gremlins --gremlin-workers=4       # use 4 workers
 ```
 
 ### Worker Timeout
@@ -322,10 +322,10 @@ def db_session():
 pytest-xdist distributes tests across workers, which conflicts with how pytest-gremlins
 controls mutation state per worker process.
 
-To parallelize mutation execution, use `--gremlin-workers`:
+To parallelize mutation execution, use `--gremlin-parallel`:
 
 ```bash
-pytest --gremlins --gremlin-workers=auto
+pytest --gremlins --gremlin-parallel
 ```
 
 This uses pytest-gremlins' own worker pool, which is built specifically for mutation isolation.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -84,10 +84,10 @@ pytest --gremlins --gremlin-cache
 pytest --gremlins --gremlin-cache --gremlin-clear-cache
 ```
 
-**Enable parallel execution:**
+**Enable parallel execution (use all CPU cores):**
 
 ```bash
-pytest --gremlins --gremlin-workers=auto
+pytest --gremlins --gremlin-parallel
 ```
 
 **Parallel with specific worker count:**
@@ -109,7 +109,7 @@ pytest --gremlins \
     --gremlin-targets=src/core \
     --gremlin-operators=comparison,boundary \
     --gremlin-cache \
-    --gremlin-workers=auto \
+    --gremlin-parallel \
     --gremlin-report=html
 ```
 
@@ -235,16 +235,16 @@ pytest --gremlins --gremlin-cache --gremlin-clear-cache
 
 ### Parallel Execution
 
-Use `--gremlin-workers` to distribute mutations across multiple worker processes. Specifying a
-worker count automatically enables parallel mode — you do not need to also pass `--gremlin-parallel`:
+Use `--gremlin-parallel` to distribute mutations across multiple worker processes. Specifying a
+worker count with `--gremlin-workers=N` automatically enables parallel mode:
 
 ```bash
-pytest --gremlins --gremlin-workers=auto   # use all CPU cores
-pytest --gremlins --gremlin-workers=4      # use 4 workers
+pytest --gremlins --gremlin-parallel        # use all CPU cores
+pytest --gremlins --gremlin-workers=4       # use 4 workers (implies --gremlin-parallel)
 ```
 
-`--gremlin-workers=auto` detects CPU count at runtime. `--gremlin-workers=1` runs sequentially
-(useful for debugging).
+`--gremlin-parallel` without `--gremlin-workers` defaults to `os.cpu_count()` workers.
+`--gremlin-workers=1` runs sequentially (useful for debugging).
 
 `--gremlins` and `-n` (pytest-xdist) cannot be combined — passing both raises an error. Use
 `--gremlin-workers` for parallel mutation execution.
@@ -272,7 +272,7 @@ For maximum speed, combine all performance options:
 ```bash
 pytest --gremlins \
     --gremlin-cache \
-    --gremlin-workers=auto \
+    --gremlin-parallel \
     --gremlin-batch \
     --gremlin-batch-size=20
 ```
@@ -307,7 +307,7 @@ jobs:
         run: |
           uv run pytest --gremlins \
             --gremlin-cache \
-            --gremlin-workers=auto \
+            --gremlin-parallel \
             --gremlin-report=json
 
       - name: Upload mutation report
@@ -324,7 +324,7 @@ mutation_testing:
   stage: test
   script:
     - pip install uv && uv sync
-    - uv run pytest --gremlins --gremlin-cache --gremlin-workers=auto --gremlin-report=json
+    - uv run pytest --gremlins --gremlin-cache --gremlin-parallel --gremlin-report=json
   artifacts:
     reports:
       junit: gremlin-report.json
@@ -343,7 +343,7 @@ repos:
     hooks:
       - id: mutation-testing
         name: Mutation Testing
-        entry: pytest --gremlins --gremlin-cache --gremlin-workers=auto
+        entry: pytest --gremlins --gremlin-cache --gremlin-parallel
         language: system
         pass_filenames: false
         stages: [pre-push]  # Run on push, not commit

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -254,7 +254,7 @@ pytest-gremlins uses several optimizations:
 - **Coverage-guided selection**: Only runs tests that cover the mutated code
 - **Early exit**: Stops testing a gremlin as soon as one test fails
 - **Incremental caching**: Skips unchanged code on subsequent runs (use `--gremlin-cache`)
-- **Parallel execution**: Distributes gremlins across CPU cores (use `--gremlin-workers=auto`)
+- **Parallel execution**: Distributes gremlins across CPU cores (use `--gremlin-parallel`)
 
 For a first run, expect 10-100x the time of a normal test run. Subsequent cached runs are much faster.
 
@@ -320,7 +320,7 @@ Try these strategies:
 
 1. **Start small**: Target specific files with `--gremlin-targets`
 2. **Use incremental mode**: `--gremlin-cache` skips unchanged code
-3. **Enable parallel execution**: `--gremlin-workers=auto`
+3. **Enable parallel execution**: `--gremlin-parallel`
 4. **Focus operators**: `--gremlin-operators=comparison,boolean`
 5. **Run in CI only**: Skip mutation testing in local development
 
@@ -340,5 +340,5 @@ Now that you understand the basics:
 | Target specific files | `pytest --gremlins --gremlin-targets=src/mymodule.py` |
 | Generate HTML report | `pytest --gremlins --gremlin-report=html` |
 | Use caching | `pytest --gremlins --gremlin-cache` |
-| Parallel execution | `pytest --gremlins --gremlin-workers=auto` |
+| Parallel execution | `pytest --gremlins --gremlin-parallel` |
 | Use specific operators | `pytest --gremlins --gremlin-operators=comparison,boolean` |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -539,7 +539,7 @@ worker process.
 Use `--gremlin-workers` instead:
 
 ```bash
-pytest --gremlins --gremlin-workers=auto   # parallel across all CPU cores
+pytest --gremlins --gremlin-parallel   # parallel across all CPU cores
 pytest --gremlins --gremlin-workers=4      # specific worker count
 ```
 
@@ -555,7 +555,7 @@ Passing both `--gremlins` and `-n` produces an explicit error.
 For parallel mutation testing, use `--gremlin-workers` instead:
 
 ```bash
-pytest --gremlins --gremlin-workers=auto   # parallel across all CPU cores
+pytest --gremlins --gremlin-parallel   # parallel across all CPU cores
 ```
 
 `--gremlin-workers=N` uses pytest-gremlins' own worker pool. Each worker runs with a different


### PR DESCRIPTION
## Summary

- `--gremlin-workers` uses `type=int` in argparse — `auto` is not a valid value and fails with a parse error
- All docs showed `--gremlin-workers=auto` as the recommended "use all CPUs" invocation
- The correct invocation is `--gremlin-parallel` (no worker count defaults to `os.cpu_count()`)
- Updated README, configuration guide, getting-started, parallelization architecture doc, and troubleshooting guide

## Related

- Adds `--gremlin-workers=auto` as a proper feature: #194 (part of UX epic #193)

## Test plan

- [ ] Verify `pytest --gremlins --gremlin-parallel` runs in parallel
- [ ] Verify `pytest --gremlins --gremlin-workers=auto` still fails with a clear parse error (until #194 ships)

Generated with [Claude Code](https://claude.ai/claude-code)