### PR TITLE
fix(docs): add project.optional-dependencies for RTD compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ dependencies = [
     "pytest>=7.0.0",
 ]
 
+[project.optional-dependencies]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.0.0",
+    "mkdocs-minify-plugin>=0.7.0",
+    "mkdocstrings[python]>=0.24.0",
+]
+
 [dependency-groups]
 docs = [
     "mkdocs>=1.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1280,6 +1280,14 @@ dependencies = [
     { name = "pytest" },
 ]
 
+[package.optional-dependencies]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-minify-plugin" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "commitizen" },
@@ -1307,8 +1315,13 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", specifier = ">=7.12.0" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
+    { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.7.0" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "pytest", specifier = ">=7.0.0" },
 ]
+provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- ReadTheDocs uses `pip install .[docs]` to install documentation dependencies
- The `docs` group was only defined under `[dependency-groups]` (PEP 735, uv-specific) — pip does not recognize this section
- RTD builds were failing with: *"cannot find module 'pymdownx.slugs' (No module named 'pymdownx')"* because `mkdocs-material` (which bundles `pymdownx`) was never installed
- Adds a mirrored `[project.optional-dependencies]` docs group so `pip install .[docs]` works correctly
- Keeps `[dependency-groups]` intact for local development with `uv sync`

Closes #45

## Test plan

- [ ] Verify `pip install .[docs]` installs all doc dependencies without error
- [ ] Verify `uv run mkdocs build --strict` still builds successfully
- [ ] Confirm RTD build passes after merge

Generated with [Claude Code](https://claude.ai/claude-code)