### PR TITLE
fix(reporting): add logging to silent exception handlers in html.py

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,9 +164,9 @@
         "filename": "src/pytest_gremlins/reporting/html.py",
         "hashed_secret": "6cec12b1a639289d9c59aa4d5bd1ca0a9795c06a",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 125
       }
     ]
   },
-  "generated_at": "2026-02-28T00:01:15Z"
+  "generated_at": "2026-02-28T00:30:45Z"
 }

--- a/src/pytest_gremlins/reporting/diff.py
+++ b/src/pytest_gremlins/reporting/diff.py
@@ -10,6 +10,7 @@ import ast
 import difflib
 import logging
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/pytest_gremlins/reporting/history.py
+++ b/src/pytest_gremlins/reporting/history.py
@@ -12,13 +12,13 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-logger = logging.getLogger(__name__)
-
 from pytest_gremlins.reporting.results import GremlinResultStatus
 
 
 if TYPE_CHECKING:
     from pytest_gremlins.reporting.score import MutationScore
+
+logger = logging.getLogger(__name__)
 
 
 def _build_operator_data(score: MutationScore) -> dict[str, dict[str, int]]:

--- a/src/pytest_gremlins/reporting/html.py
+++ b/src/pytest_gremlins/reporting/html.py
@@ -11,14 +11,15 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-logger = logging.getLogger(__name__)
-
 from pytest_gremlins.reporting.diff import _compute_diff, _node_to_source
 from pytest_gremlins.reporting.history import (
     _build_operator_data,
     append_history_entry,
     load_history,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:

--- a/tests/reporting/test_html.py
+++ b/tests/reporting/test_html.py
@@ -825,7 +825,6 @@ class DescribeHtmlReporterHistorySection:
 
 
 @pytest.mark.small
-<<<<<<< HEAD
 class DescribeHtmlReporterA11y:
     """Tests for WCAG-compliant accessibility in the HTML report.
 
@@ -1046,6 +1045,8 @@ class DescribeBuildOperatorData:
         result = _build_operator_data(score)
 
         assert result['comparison'] == {'total': 4, 'survived': 1}
+
+
 @pytest.mark.small
 class DescribeNodeToSourceLogging:
     """Tests for logging in _node_to_source when AST unparsing fails."""


### PR DESCRIPTION
## Summary

- Add `import logging` and `logger = logging.getLogger(__name__)` module-level logger
- `_node_to_source` except block: `logger.warning('Failed to get source for AST node', exc_info=True)`
- `append_history_entry` except block: `logger.warning('Could not read existing history from %s, starting fresh', path, exc_info=True)`
- `load_history` except block: `logger.warning('Could not load history from %s', history_path, exc_info=True)`
- `write_report`: `logger.info('HTML report written to %s', output_path)` after successful write
- 4 new `@pytest.mark.small` tests using `caplog` fixture to assert each log call fires with the expected message

All 4 logging calls confirmed covered by the caplog tests (verified line-by-line against coverage report).

Closes #218

## Test plan

- [x] `uv run pytest tests -m "small or medium" -q` — 948 passed, 1 skipped
- [x] Pre-push hooks (ruff, mypy strict, small tests) all green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)