### PR TITLE
fix(release): add annotated_tag and fix changelog extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,9 +243,16 @@ jobs:
           VERSION="${GIT_REF#refs/tags/v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Extract changelog section for this version
-          # This assumes commitizen changelog format
-          awk "/^## v?$VERSION/,/^## v?[0-9]/" CHANGELOG.md | head -n -1 > release_notes.md
+          # Extract changelog section for this version.
+          # The range pattern /start/,/end/ misfires when the start line also matches
+          # the end pattern (e.g. "## v1.4.0" matches both /v?1.4.0/ and /v?[0-9]/).
+          # Use a stateful awk instead: print lines after the version header is found,
+          # stopping (without printing) when the next section header appears.
+          awk "
+            found && /^## v?[0-9]/ { exit }
+            /^## v?$VERSION/       { found=1 }
+            found                  { print }
+          " CHANGELOG.md > release_notes.md
 
           # If no specific section found, use a default message
           if [ ! -s release_notes.md ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,42 @@ uv run pytest --doctest-modules src/pytest_gremlins
 - `.github/workflows/release.yml` - Release pipeline with Test PyPI
 - `.github/workflows/cut-release.yml` - One-click version bump + tag (triggers release.yml)
 - `scripts/release.sh` - Local release script (same thing, from your terminal)
+
+## Release Process
+
+**Never run `cz bump` locally.** The `no-commit-to-branch` pre-commit hook blocks commits
+to `main`, so a local bump will fail mid-run and leave a dirty version bump to revert.
+
+Use the workflow dispatch instead:
+
+```bash
+gh workflow run cut-release.yml --repo SayMoreAI/pytest-gremlins
+```
+
+This runs `cz bump` on the GitHub Actions runner (no local hooks), commits the version,
+creates an annotated tag, and pushes — which triggers `release.yml`.
+
+After dispatching, verify the tag landed:
+
+```bash
+git fetch --tags
+git ls-remote --tags origin | tail -5
+```
+
+If the tag is missing, `--follow-tags` silently skipped a lightweight tag. Root cause:
+`[tool.commitizen]` must have `annotated_tag = true`. Without it, commitizen creates
+lightweight tags that `--follow-tags` ignores.
+
+**RELEASE_PAT secret**: The workflow requires a `RELEASE_PAT` repo secret with
+`contents: write` and `workflows: write` scopes. Set it to never expire — an expired
+PAT causes a silent checkout failure with no useful error message.
+
+## Demo Videos
+
+Narrated MP4 demos live on YouTube (not committed to git). The `.gitignore` excludes `*.mp4` and `*.webm`.
+
+Demo project files live under `/tmp/gremlin-demo-<epic>` (or similar per-epic dirs).
+Each demo project's `pyproject.toml` must include `pytest-xdist` as a dependency —
+the dev plugin registers a `pytest_configure_node` hook that pluggy rejects at
+`check_pending()` if xdist is absent, causing silent `pytest_sessionfinish` failure
+(the HTML report never writes).

--- a/cspell.json
+++ b/cspell.json
@@ -176,6 +176,7 @@
     "uv",
     "venv",
     "virtualenv",
+    "WCAG",
     "worktree",
     "worktrees",
     "wsgi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,7 @@ directory = "htmlcov"
 # =============================================================================
 [tool.commitizen]
 name = "cz_conventional_commits"
+annotated_tag = true
 version = "1.4.0"
 version_files = [
     "pyproject.toml:version",

--- a/uv.lock
+++ b/uv.lock
@@ -1356,7 +1356,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

- **`annotated_tag = true`** added to `[tool.commitizen]` — without this, `cz bump` creates lightweight tags that `git push --follow-tags` silently skips, so no release ever fires from CI
- **Stateful awk** replaces the broken range pattern in `release.yml` — the old `END` pattern `/^## v?[0-9]/` matched the `START` line itself (e.g. `## v1.4.0` since `1` is a digit); GNU awk terminates a range immediately when one line matches both patterns, leaving `release_notes.md` empty and triggering the `"Release X.Y.Z"` fallback
- **`CLAUDE.md`** updated with release process and demo video notes
- **`cspell.json`** adds WCAG to the dictionary

## Root cause of v1.4.0 missing changelog

1. CI ran `cz bump` → created bump commit + **lightweight** tag
2. `git push --follow-tags` pushed the commit but silently skipped the lightweight tag
3. `release.yml` never triggered from CI; user manually pushed an annotated tag
4. `release.yml` ran but the awk range captured only the section header, then `head -n -1` removed it → empty `release_notes.md` → fallback body `"Release 1.4.0"`

## Test plan

- [ ] Verify `cz bump` in CI now creates annotated tags (`git cat-file -t vX.Y.Z` → `tag`, not `commit`)
- [ ] Trigger a release and confirm the GitHub Release body contains the CHANGELOG section

Fixes #236

🤖 Generated with [Claude Code](https://claude.ai/claude-code)