### PR TITLE
fix(release): add explicit tag push as safety net in cut-release.yml

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -78,10 +78,17 @@ jobs:
           echo "new_tag=${new_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Push commit and tag
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "Pushing ${{ steps.bump.outputs.new_tag }} to origin..."
-          if ! git push origin HEAD:refs/heads/${{ github.ref_name }} --follow-tags 2>&1; then
+          echo "Pushing ${NEW_TAG} to origin..."
+          if ! git push origin "HEAD:refs/heads/${REF_NAME}" --follow-tags 2>&1; then
             echo "::error::git push failed. The RELEASE_PAT secret may have expired (90-day expiry). Verify the token at Settings > Secrets > RELEASE_PAT."
+            exit 1
+          fi
+          if ! git push origin "${NEW_TAG}" 2>&1; then
+            echo "::error::Tag push failed for ${NEW_TAG}. Verify the RELEASE_PAT secret has not expired."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Closes #232

`--follow-tags` pushes annotated tags alongside the commit push but produces no separate CI log entry, making it impossible to confirm from the workflow summary that the tag actually landed. This PR adds an explicit `git push origin "${NEW_TAG}"` after the commit push as a belt-and-suspenders safety net.

Also refactors `${{ steps.bump.outputs.new_tag }}` and `${{ github.ref_name }}` out of the `run:` block into `env:` variables per GitHub Actions injection-prevention guidelines (both were low-risk — `new_tag` is a semver string produced by `cz bump`, not user input — but the safe pattern costs nothing and silences security scanners).

## What changed

**`.github/workflows/cut-release.yml` — Push commit and tag step:**

```diff
-       - name: Push commit and tag
-         run: |
-           echo "Pushing ${{ steps.bump.outputs.new_tag }} to origin..."
-           if ! git push origin HEAD:refs/heads/${{ github.ref_name }} --follow-tags 2>&1; then
-             echo "::error::git push failed. ..."
-             exit 1
-           fi
+       - name: Push commit and tag
+         env:
+           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+           REF_NAME: ${{ github.ref_name }}
+         run: |
+           echo "Pushing ${NEW_TAG} to origin..."
+           if ! git push origin "HEAD:refs/heads/${REF_NAME}" --follow-tags 2>&1; then
+             echo "::error::git push failed. ..."
+             exit 1
+           fi
+           if ! git push origin "${NEW_TAG}" 2>&1; then
+             echo "::error::Tag push failed for ${NEW_TAG}. ..."
+             exit 1
+           fi
```

## Acceptance criteria verified

These criteria require a real release run to confirm — they cannot be unit tested. The belt-and-suspenders design means:
- If `--follow-tags` works: both commands succeed, tag lands once (git is idempotent for already-pushed refs)
- If `--follow-tags` silently skips the tag for any reason: the explicit push catches it and fails loudly

## Notes

`annotated_tag = true` was already added to `pyproject.toml` in PR #235. This PR completes the second half of issue #232.

---

Generated with [Claude Code](https://claude.ai/claude-code)