### PR TITLE
fix(types): replace cast(Any, node) with _XdistWorkerNode Protocol

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -28,8 +28,7 @@ import sys
 import tempfile
 from typing import (
     TYPE_CHECKING,
-    Any,
-    cast,
+    Protocol,
 )
 import warnings
 
@@ -74,6 +73,13 @@ if TYPE_CHECKING:
 
 
 _XDIST_AVAILABLE = importlib.util.find_spec('xdist') is not None
+
+
+class _XdistWorkerNode(Protocol):
+    """Structural type for an xdist worker node that exposes ``workerinput``."""
+
+    workerinput: dict[str, object]
+
 
 logger = logging.getLogger(__name__)
 
@@ -475,7 +481,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 if _XDIST_AVAILABLE:
 
-    def pytest_configure_node(node: object) -> None:
+    def pytest_configure_node(node: _XdistWorkerNode) -> None:
         """Inject gremlins tmpdir into xdist worker input for PRIVATE coverage mode.
 
         Called on the controller for each xdist worker node before it starts.
@@ -495,7 +501,7 @@ if _XDIST_AVAILABLE:
         if gremlin_session.coverage_mode != CoverageMode.PRIVATE:
             return
 
-        cast('Any', node).workerinput['gremlins_tmpdir'] = gremlin_session.gremlins_tmpdir
+        node.workerinput['gremlins_tmpdir'] = gremlin_session.gremlins_tmpdir
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/tests/parallel/test_xdist_protocol.py
+++ b/tests/parallel/test_xdist_protocol.py
@@ -1,0 +1,36 @@
+"""Tests for the _XdistWorkerNode Protocol used in pytest_configure_node."""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from pytest_gremlins.plugin import _XdistWorkerNode
+
+
+@pytest.mark.small
+class DescribeXdistWorkerNodeProtocol:
+    """Tests for the _XdistWorkerNode Protocol."""
+
+    def it_is_a_protocol(self) -> None:
+        """_XdistWorkerNode is a typing.Protocol."""
+        assert issubclass(_XdistWorkerNode, typing.Protocol)
+
+    def it_accepts_object_with_workerinput_dict(self) -> None:
+        """An object with workerinput dict[str, object] satisfies the protocol."""
+
+        class FakeNode:
+            workerinput: dict[str, object]
+
+            def __init__(self) -> None:
+                self.workerinput = {}
+
+        node: _XdistWorkerNode = FakeNode()  # type: ignore[assignment]
+        node.workerinput['gremlin_active'] = False
+        assert node.workerinput['gremlin_active'] is False
+
+    def it_exposes_workerinput_attribute(self) -> None:
+        """_XdistWorkerNode Protocol declares workerinput as a required attribute."""
+        hints = typing.get_type_hints(_XdistWorkerNode)
+        assert 'workerinput' in hints


### PR DESCRIPTION
## Summary

- Define `_XdistWorkerNode(Protocol)` with `workerinput: dict[str, object]`
- Type `pytest_configure_node(node: _XdistWorkerNode)` — removes the `cast('Any', node)` escape hatch
- Replace `Any, cast` imports with `Protocol` in the typing import block
- Add `tests/parallel/test_xdist_protocol.py` verifying the Protocol contract

## Why

`cast('Any', ...)` is a type-safety escape hatch that silences mypy without actually proving the attribute exists. A structural `Protocol` expresses the same guarantee but mypy can actually check it — if xdist ever renames `workerinput`, we get a type error instead of a runtime `AttributeError`.

## Test plan

- [x] `tests/parallel/test_xdist_protocol.py` — TDD red/green cycle verifies Protocol existence and structure
- [x] `uv run mypy src/pytest_gremlins` — no issues (47 source files)
- [x] `uv run pytest tests -m small -q` — 851 passed, 1 skipped
- [x] `uv run ruff check src tests` — all checks passed
- [x] Pre-push hooks (ruff, mypy strict, small tests) — all green

Closes #203

🤖 Generated with [Claude Code](https://claude.ai/claude-code)