### PR TITLE
feat(parallel): add --gremlin-workers=auto support

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -316,9 +316,12 @@ def _workers_type(value: str) -> int:
     if value == 'auto':
         return os.cpu_count() or 4
     try:
-        return int(value)
+        workers = int(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f'Invalid workers value: {value!r}') from exc
+    if workers <= 0:
+        raise argparse.ArgumentTypeError(f'Workers must be a positive integer, got {value!r}')
+    return workers
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/parallel/test_workers_type.py
+++ b/tests/parallel/test_workers_type.py
@@ -32,3 +32,13 @@ class DescribeWorkersType:
         """A non-numeric, non-'auto' string raises argparse.ArgumentTypeError."""
         with pytest.raises(argparse.ArgumentTypeError):
             _workers_type('invalid')
+
+    def it_raises_argument_type_error_for_zero(self) -> None:
+        """Zero is not a valid worker count and raises argparse.ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            _workers_type('0')
+
+    def it_raises_argument_type_error_for_negative_integer(self) -> None:
+        """A negative integer is not a valid worker count and raises argparse.ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            _workers_type('-1')


### PR DESCRIPTION
## Summary

- Add `_workers_type(value: str) -> int` custom argparse type for `--gremlin-workers`
- `--gremlin-workers=auto` resolves to `os.cpu_count() or 4` (fallback when cpu_count returns None)
- `--gremlin-workers=N` still works for any positive integer N
- Zero and negative values now raise `ArgumentTypeError` with a clear message
- Non-numeric strings raise `ArgumentTypeError` (same as before, but with better error origin)

## Why

`type=int` silently accepted `0` and `-1`, which would produce nonsensical parallel execution. The `auto` keyword lets users skip the CPU-count lookup and get a sensible default on any machine.

## Test plan

- [x] `it_returns_cpu_count_for_auto` — mocked cpu_count=8 → returns 8
- [x] `it_falls_back_to_4_when_cpu_count_is_none` — cpu_count=None → returns 4
- [x] `it_parses_a_numeric_string_as_int` — `"2"` → 2
- [x] `it_raises_argument_type_error_for_invalid_input` — `"invalid"` → ArgumentTypeError
- [x] `it_raises_argument_type_error_for_zero` — `"0"` → ArgumentTypeError *(gauntlet-found)*
- [x] `it_raises_argument_type_error_for_negative_integer` — `"-1"` → ArgumentTypeError *(gauntlet-found)*
- [x] `uv run mypy src/pytest_gremlins` — no issues (47 source files)
- [x] `uv run pytest tests -m small -q` — 854 passed, 1 skipped
- [x] `uv run ruff check src tests` — all checks passed
- [x] Pre-push hooks (ruff, mypy strict, small tests) — all green

Closes #194

🤖 Generated with [Claude Code](https://claude.ai/claude-code)