### PR TITLE
test(pardoning): add medium pytester E2E tests for pardoning, thresholds, audit, and batch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def make_pytest_config() -> Callable[..., Any]:
         strict_pardons: bool = False,
         gremlin_audit_pardons: bool = False,
         gremlin_max_pardons_pct: float | None = None,
+        max_pardons: int | None = None,
         pluginmanager: MagicMock | None = None,
     ) -> object:
         class _Option:
@@ -118,6 +119,7 @@ def make_pytest_config() -> Callable[..., Any]:
         option.strict_pardons = strict_pardons  # type: ignore[attr-defined]
         option.gremlin_audit_pardons = gremlin_audit_pardons  # type: ignore[attr-defined]
         option.gremlin_max_pardons_pct = gremlin_max_pardons_pct  # type: ignore[attr-defined]
+        option.max_pardons = max_pardons  # type: ignore[attr-defined]
 
         if pluginmanager is None:
             pm: MagicMock = MagicMock()

--- a/tests/plugin/test_e2e_pardoning.py
+++ b/tests/plugin/test_e2e_pardoning.py
@@ -1,0 +1,97 @@
+"""Medium pytester E2E tests for pardoning features.
+
+Covers the full pardoning workflow end-to-end: the ``# gremlin: survivor[...]``
+pragma, threshold flags (--max-pardons, --gremlin-max-pardons-pct),
+--strict-pardons, --gremlin-audit-pardons, and --gremlin-batch with pardons.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def pardoned_project(pytester_with_markers: pytest.Pytester) -> pytest.Pytester:
+    """Pytester project with one pardoned arithmetic mutation."""
+    pytester_with_markers.makepyfile(
+        src_module="""
+def add(a, b):
+    return a + b  # gremlin: survivor[equivalent] addition is equivalent here
+""",
+    )
+    pytester_with_markers.makepyfile(
+        test_src="""
+from src_module import add
+
+def test_add():
+    assert add(2, 3) == 5
+""",
+    )
+    return pytester_with_markers
+
+
+@pytest.mark.medium
+class DescribeE2EPardoning:
+    def it_pardoned_gremlin_reports_pardoned_status(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest('--gremlins', '--gremlin-targets=src_module.py')
+
+        assert 'Pardoned:' in result.stdout.str()
+
+    def it_pardoned_gremlin_excluded_from_score(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest('--gremlins', '--gremlin-targets=src_module.py')
+
+        assert result.ret == 0
+
+    def it_max_pardons_fails_when_exceeded(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--max-pardons=0',
+        )
+
+        assert result.ret != 0
+
+    def it_max_pardons_passes_when_within_limit(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--max-pardons=5',
+        )
+
+        assert result.ret == 0
+
+    def it_max_pardons_pct_fails_when_exceeded(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--gremlin-max-pardons-pct=0.0',
+        )
+
+        assert result.ret != 0
+
+    def it_strict_pardons_fails_with_any_pardon(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--strict-pardons',
+        )
+
+        assert result.ret != 0
+
+    def it_audit_pardons_lists_pardon_details(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--gremlin-audit-pardons',
+        )
+
+        assert 'equivalent' in result.stdout.str()
+
+    def it_batch_mode_pardons(self, pardoned_project: pytest.Pytester) -> None:
+        result = pardoned_project.runpytest(
+            '--gremlins',
+            '--gremlin-targets=src_module.py',
+            '--gremlin-batch',
+        )
+
+        assert 'Pardoned:' in result.stdout.str()

--- a/tests/plugin/test_max_pardons.py
+++ b/tests/plugin/test_max_pardons.py
@@ -165,37 +165,18 @@ class DescribeMaxPardons:
 
         assert merged.max_pardons == 3
 
-    def it_toml_max_pardons_flows_into_session(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def it_toml_max_pardons_flows_into_session(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        make_pytest_config: object,
+    ) -> None:
         pyproject = tmp_path / 'pyproject.toml'
         pyproject.write_text('[tool.pytest-gremlins]\nmax_pardons = 4\n')
 
         monkeypatch.setattr('pytest_gremlins.plugin._gremlin_session', None)
 
-        class _MockOption:
-            gremlins = True
-            gremlin_report = None
-            gremlin_cache = False
-            gremlin_clear_cache = False
-            gremlin_parallel = False
-            gremlin_workers: int | None = None
-            gremlin_batch = False
-            gremlin_batch_size: int | None = None
-            gremlin_operators = None
-            gremlin_targets = None
-            gremlin_max_pardons_pct: float | None = None
-            strict_pardons = False
-            gremlin_audit_pardons = False
-            max_pardons: int | None = None
-
-        class _MockConfig:
-            pass
-
-        cfg = _MockConfig()
-        cfg.option = _MockOption()  # type: ignore[attr-defined]
-        cfg.rootdir = tmp_path  # type: ignore[attr-defined]
-        mock_pm = MagicMock()
-        mock_pm.get_plugin.return_value = None
-        cfg.pluginmanager = mock_pm  # type: ignore[attr-defined]
+        cfg = make_pytest_config(tmp_path)  # type: ignore[operator]
 
         pytest_configure(cfg)  # type: ignore[arg-type]
 
@@ -296,34 +277,15 @@ class DescribeMaxPardons:
         assert '7' in caplog.records[0].message
         assert '5' in caplog.records[0].message
 
-    def it_rejects_out_of_range_max_pardons_via_cli(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def it_rejects_out_of_range_max_pardons_via_cli(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        make_pytest_config: object,
+    ) -> None:
         monkeypatch.setattr('pytest_gremlins.plugin._gremlin_session', None)
 
-        class _MockOption:
-            gremlins = True
-            gremlin_report = None
-            gremlin_cache = False
-            gremlin_clear_cache = False
-            gremlin_parallel = False
-            gremlin_workers: int | None = None
-            gremlin_batch = False
-            gremlin_batch_size: int | None = None
-            gremlin_operators = None
-            gremlin_targets = None
-            gremlin_max_pardons_pct: float | None = None
-            strict_pardons = False
-            gremlin_audit_pardons = False
-            max_pardons: int | None = -1  # invalid: negative
-
-        class _MockConfig:
-            pass
-
-        cfg = _MockConfig()
-        cfg.option = _MockOption()  # type: ignore[attr-defined]
-        cfg.rootdir = tmp_path  # type: ignore[attr-defined]
-        mock_pm = MagicMock()
-        mock_pm.get_plugin.return_value = None
-        cfg.pluginmanager = mock_pm  # type: ignore[attr-defined]
+        cfg = make_pytest_config(tmp_path, max_pardons=-1)  # type: ignore[operator]
 
         with patch('pytest_gremlins.plugin.pytest') as mock_pytest:
             pytest_configure(cfg)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Add 8 medium `pytester` E2E tests that run `pytest --gremlins` in a subprocess and verify the full pardoning flow end-to-end (output, exit codes, threshold enforcement)
- Add `max_pardons` parameter to the shared `make_pytest_config` factory in `tests/conftest.py`
- Refactor 2 tests in `test_max_pardons.py` from inline `_MockOption` to the shared factory, reducing drift risk

## Why pytester?

`plugin.py` calls module-level functions directly — there's no DI interface to inject fakes into. Medium pytester tests spawn a real pytest subprocess and verify terminal output + exit codes, exercising the real plugin hooks, config loading, and execution paths.

## Tests added (`tests/plugin/test_e2e_pardoning.py`)

| Test | What it proves |
|------|---------------|
| `it_pardoned_gremlin_reports_pardoned_status` | Pragma → `Pardoned:` in output |
| `it_pardoned_gremlin_excluded_from_score` | Pardoned gremlins don't fail the score |
| `it_max_pardons_fails_when_exceeded` | `--max-pardons=0` → non-zero exit |
| `it_max_pardons_passes_when_within_limit` | `--max-pardons=5` → exit 0 |
| `it_max_pardons_pct_fails_when_exceeded` | `--gremlin-max-pardons-pct=0.0` → non-zero exit |
| `it_strict_pardons_fails_with_any_pardon` | `--strict-pardons` → non-zero exit |
| `it_audit_pardons_lists_pardon_details` | `--gremlin-audit-pardons` → reason in output |
| `it_batch_mode_pardons` | `--gremlin-batch` → `Pardoned:` in output |

## Verification

- ✅ All 8 medium tests pass (`14.09s`)
- ✅ 1042 small tests pass, no regressions
- ✅ `mypy` strict: no issues
- ✅ `ruff`: all checks passed
- ✅ Pre-push hooks: ruff full codebase, mypy strict, pytest small — all green
- ✅ Gauntlet: bug hunt, quality, security, church sweep — all PASS

Closes #271

---
Generated with [Claude Code](https://claude.ai/claude-code)