### PR TITLE
fix(ci): disable hermeticity enforcement for doctest run (#299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,10 @@ jobs:
         run: uv sync
 
       - name: Run doctests
-        run: uv run pytest --doctest-modules src/pytest_gremlins
+        # Disable test-category hermeticity enforcement for doctests: doctests
+        # have no mechanism to declare a size marker, so pytest-test-categories
+        # flags incidental reads (e.g. ~/.pdbrc from pdb internals) as violations.
+        run: uv run pytest --doctest-modules src/pytest_gremlins --override-ini="test_categories_enforcement=disabled"
 
       - name: Build docs
         run: uv run mkdocs build --strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,9 @@ uv run tox
 uv run mkdocs build --strict
 
 # Run doctests
-uv run pytest --doctest-modules src/pytest_gremlins
+# Filesystem isolation checks are disabled: doctests can't carry pytest markers,
+# so pytest-test-categories flags pdb reading its config file as a violation.
+uv run pytest --doctest-modules src/pytest_gremlins --override-ini="test_categories_enforcement=disabled"
 ```
 
 ## CI Caching


### PR DESCRIPTION
## Summary

Fixes the Documentation CI job, which was failing with 31 `FilesystemAccessViolationError` errors on every PR that touched `src/`.

- Adds `--override-ini="test_categories_enforcement=disabled"` to the `--doctest-modules` run only
- Regular test suite continues to run with `strict` enforcement
- Updates the CLAUDE.md doctest command to match

## Root cause

Doctests have no mechanism to carry pytest markers, so `pytest-test-categories` in strict mode classifies them all as `SMALL` and then fails any that touch the filesystem. The violation isn't in the doctest code — it's pdb reading its config file during setup. There's no way to fix this without either suppressing the check for doctests or rewriting every doctest to mock pdb internals.

## Verification

```
uv run pytest --doctest-modules src/pytest_gremlins --override-ini="test_categories_enforcement=disabled"
# 31 passed, 2 skipped
```

Closes #299

---

Generated with [Claude Code](https://claude.ai/claude-code)