### PR TITLE
fix(release): document changelog-first process and disable auto-changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,6 @@ version_files = [
     "src/pytest_gremlins/__init__.py:__version__",
 ]
 tag_format = "v$version"
-update_changelog_on_bump = true
+update_changelog_on_bump = false
 changelog_file = "CHANGELOG.md"
 changelog_incremental = true


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: corrects repository owner (`SayMoreAI` → `mikelane/pytest-gremlins`), adds explicit Step 1 (update CHANGELOG.md before dispatching `cut-release.yml`)
- **pyproject.toml**: sets `update_changelog_on_bump = false` — changelogs are now written manually before each release; commitizen handles version bumping only

## Why

`cz bump` with `changelog_incremental = true` + `update_changelog_on_bump = true` silently aborts when it can't build an incremental changelog (no prior stable tag to diff from during beta→stable promotion). This left `v1.5.0` untagged after two dispatch attempts. Disabling auto-changelog lets `cz bump` do its one job (bump and tag) without touching the file we've already updated manually.

## Test plan

- [ ] CI passes
- [ ] After merge, `cut-release.yml` dispatches cleanly and creates `v1.5.0` tag

🤖 Generated with [Claude Code](https://claude.ai/claude-code)