### PR TITLE
chore: gitignore .claude/plans/ and sync uv.lock to v1.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ build/
 .claude/settings.local.json
 .claude/*.local.md
 .claude/todos/
+.claude/plans/
 
 # Local development
 .env.local

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

- Add `.claude/plans/` to `.gitignore` (local Claude Code plans directory)
- Sync `uv.lock` to v1.7.0 — the `cz bump` commit (`cafb08d`) updated `pyproject.toml` but missed regenerating the lockfile, causing pre-commit hook failures on subsequent pushes

## Test plan

- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass (ruff, mypy, pytest small)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)