### PR TITLE
fix: use full node IDs in coverage selection to support duplicate test names

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -233,45 +233,44 @@ _gremlin_session: GremlinSession | None = None
 
 
 def _extract_test_name_from_context(context: str) -> str:
-    """Extract the test function name from a coverage dynamic context string.
+    """Extract the test identifier from a coverage dynamic context string.
 
     Handles two context formats:
 
     - **New format** (GremlinContextPlugin): ``{nodeid}|{when}``
       e.g. ``tests/test_foo.py::TestClass::test_bar|run``
-      The nodeid part is everything before ``|``; the function name is the
-      last ``::``-separated segment of the nodeid.
+      Returns the full node ID (everything before ``|``), preserving the
+      file path and class qualifiers so that tests with the same function
+      name in different files are distinguishable.
 
     - **Old format** (coverage dynamic_context=test_function):
-      e.g. ``test_bar`` or ``TestClass.test_method`` or ``path::test_func``
-      The function name is the last ``::`` or ``.``-separated segment.
+      e.g. ``test_bar`` or ``TestClass.test_method``
+      Returns the value as-is (no ``|`` present, no transformation).
 
     Args:
         context: The raw context string from the coverage database.
 
     Returns:
-        The test function name extracted from the context.
+        The full node ID for new-format contexts, or the original value
+        for old-format contexts.
 
     Examples:
         >>> _extract_test_name_from_context('tests/test_foo.py::test_bar|run')
-        'test_bar'
+        'tests/test_foo.py::test_bar'
         >>> _extract_test_name_from_context('tests/test_foo.py::test_bar|setup')
-        'test_bar'
+        'tests/test_foo.py::test_bar'
         >>> _extract_test_name_from_context('tests/test_foo.py::TestFoo::test_bar|run')
-        'test_bar'
+        'tests/test_foo.py::TestFoo::test_bar'
         >>> _extract_test_name_from_context('test_bar')
         'test_bar'
         >>> _extract_test_name_from_context('TestClass.test_method')
-        'test_method'
+        'TestClass.test_method'
         >>> _extract_test_name_from_context('tests/test_foo.py::test_func')
-        'test_func'
+        'tests/test_foo.py::test_func'
     """
     if '|' in context:
-        nodeid = context.split('|', maxsplit=1)[0]
-        return nodeid.split('::')[-1] if '::' in nodeid else nodeid
-    if '::' in context:
-        return context.rsplit('::', maxsplit=1)[-1]
-    return context.rsplit('.', maxsplit=1)[-1]
+        return context.split('|', maxsplit=1)[0]
+    return context
 
 
 def _is_xdist_worker(config: pytest.Config) -> bool:
@@ -877,9 +876,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     rootdir = _get_rootdir(session.config)
     node_ids = [item.nodeid for item in session.items]
     normalized_node_ids = _make_node_ids_relative(node_ids, rootdir)
-    gremlin_session.test_node_ids = {
-        item.name: node_id for item, node_id in zip(session.items, normalized_node_ids, strict=True)
-    }
+    gremlin_session.test_node_ids = {node_id: node_id for node_id in normalized_node_ids}
 
     source_files = _discover_source_files(session, gremlin_session)
     gremlin_session.source_files = source_files
@@ -2192,6 +2189,13 @@ def _build_test_hashes_for_gremlin(
         if not node_id:
             simple_name = test_name.split('.')[-1]
             node_id = gremlin_session.test_node_ids.get(simple_name, '')
+        if not node_id:
+            # Coverage map may use bare function names (old-format dynamic_context)
+            # while test_node_ids is keyed by full node ID.  Search by suffix match.
+            for nid in gremlin_session.test_node_ids:
+                if nid.endswith(('::' + test_name, '::' + test_name.split('.')[-1])):
+                    node_id = nid
+                    break
 
         if '::' in node_id:
             test_file = node_id.split('::')[0]

--- a/tests/plugin/test_context_parsing.py
+++ b/tests/plugin/test_context_parsing.py
@@ -3,13 +3,13 @@
 The context format used by GremlinContextPlugin is:
     ``{nodeid}|{when}``  e.g. ``tests/test_foo.py::test_bar|run``
 
-The nodeid part is ``tests/test_foo.py::test_bar`` and the function name is
-extracted as the last ``::``-separated segment: ``test_bar``.
+The function returns the full node ID (everything before ``|``) so that
+tests with the same function name in different files are distinguishable.
 
-The old dynamic_context=test_function format (without ``|``) is also handled
-as a fallback:
+The old dynamic_context=test_function format (without ``|``) is returned
+as-is:
     ``test_bar``  -> ``test_bar``
-    ``TestClass.test_method`` -> ``test_method``
+    ``TestClass.test_method`` -> ``TestClass.test_method``
 """
 
 from __future__ import annotations
@@ -21,46 +21,46 @@ from pytest_gremlins.plugin import _extract_test_name_from_context
 
 @pytest.mark.small
 class DescribeExtractTestNameFromContext:
-    """_extract_test_name_from_context parses both old and new context formats."""
+    """_extract_test_name_from_context returns full node IDs for new format, passthrough for old."""
 
-    def it_returns_function_name_for_new_format_run_phase(self) -> None:
-        """New format 'nodeid|run' returns the test function name."""
+    def it_returns_full_nodeid_for_new_format_run_phase(self) -> None:
+        """New format 'nodeid|run' returns the full node ID."""
         result = _extract_test_name_from_context('tests/test_foo.py::test_bar|run')
-        assert result == 'test_bar'
+        assert result == 'tests/test_foo.py::test_bar'
 
-    def it_returns_function_name_for_new_format_setup_phase(self) -> None:
-        """New format 'nodeid|setup' still returns the test function name, not 'setup'."""
+    def it_returns_full_nodeid_for_new_format_setup_phase(self) -> None:
+        """New format 'nodeid|setup' strips the phase, returns the full node ID."""
         result = _extract_test_name_from_context('tests/test_foo.py::test_bar|setup')
-        assert result == 'test_bar'
+        assert result == 'tests/test_foo.py::test_bar'
 
-    def it_returns_function_name_for_new_format_teardown_phase(self) -> None:
-        """New format 'nodeid|teardown' still returns the test function name."""
+    def it_returns_full_nodeid_for_new_format_teardown_phase(self) -> None:
+        """New format 'nodeid|teardown' strips the phase, returns the full node ID."""
         result = _extract_test_name_from_context('tests/test_foo.py::test_bar|teardown')
-        assert result == 'test_bar'
+        assert result == 'tests/test_foo.py::test_bar'
 
-    def it_returns_method_name_for_new_format_with_class(self) -> None:
-        """New format with class::method extracts the method name."""
+    def it_returns_full_nodeid_for_new_format_with_class(self) -> None:
+        """New format with class preserves file::class::method in the result."""
         result = _extract_test_name_from_context('tests/test_foo.py::TestFoo::test_bar|run')
-        assert result == 'test_bar'
+        assert result == 'tests/test_foo.py::TestFoo::test_bar'
 
     def it_produces_different_result_for_different_function_name(self) -> None:
-        """Different function names produce different results - rules out hardcoding."""
+        """Different node IDs produce different results - rules out hardcoding."""
         result_a = _extract_test_name_from_context('tests/test_foo.py::test_alpha|run')
         result_b = _extract_test_name_from_context('tests/test_foo.py::test_beta|run')
-        assert result_a == 'test_alpha'
-        assert result_b == 'test_beta'
+        assert result_a == 'tests/test_foo.py::test_alpha'
+        assert result_b == 'tests/test_foo.py::test_beta'
 
     def it_returns_name_unchanged_for_old_format_plain_name(self) -> None:
         """Old dynamic_context format with plain function name passes through."""
         result = _extract_test_name_from_context('test_bar')
         assert result == 'test_bar'
 
-    def it_returns_last_segment_for_old_format_dotted_name(self) -> None:
-        """Old format 'Module.test_method' returns just 'test_method'."""
+    def it_returns_value_unchanged_for_old_format_dotted_name(self) -> None:
+        """Old format 'TestClass.test_method' passes through unchanged."""
         result = _extract_test_name_from_context('TestClass.test_method')
-        assert result == 'test_method'
+        assert result == 'TestClass.test_method'
 
-    def it_returns_last_segment_for_old_format_double_colon(self) -> None:
-        """Old format 'path::test_func' (no pipe) returns 'test_func'."""
+    def it_returns_value_unchanged_for_old_format_double_colon(self) -> None:
+        """Old format 'path::test_func' (no pipe) passes through unchanged."""
         result = _extract_test_name_from_context('tests/test_foo.py::test_func')
-        assert result == 'test_func'
+        assert result == 'tests/test_foo.py::test_func'

--- a/tests/plugin/test_plugin_helpers.py
+++ b/tests/plugin/test_plugin_helpers.py
@@ -675,8 +675,8 @@ class DescribeExtractTestNameFromContext:
         # ACT
         result = _extract_test_name_from_context(context)
 
-        # ASSERT — must return the function name, not the class or file path.
-        assert result == 'test_bar'
+        # ASSERT — full node ID preserved, only |when stripped
+        assert result == 'tests/test_foo.py::TestFoo::test_bar'
 
     def it_extracts_function_name_from_pipe_format_setup_phase(self) -> None:
         # ARRANGE — 'setup' phase; the when-segment must be stripped.
@@ -685,8 +685,8 @@ class DescribeExtractTestNameFromContext:
         # ACT
         result = _extract_test_name_from_context(context)
 
-        # ASSERT
-        assert result == 'test_bar'
+        # ASSERT — full node ID preserved, only |setup stripped
+        assert result == 'tests/test_foo.py::test_bar'
 
     def it_returns_raw_nodeid_when_pipe_format_has_no_colons(self) -> None:
         # ARRANGE — nodeid contains no '::'; returned as-is after stripping '|when'.
@@ -705,18 +705,18 @@ class DescribeExtractTestNameFromContext:
         # ACT
         result = _extract_test_name_from_context(context)
 
-        # ASSERT
-        assert result == 'test_func'
+        # ASSERT — full identifier preserved
+        assert result == 'tests/test_foo.py::test_func'
 
-    def it_extracts_method_name_from_dot_separated_class_format(self) -> None:
+    def it_returns_full_dot_separated_context(self) -> None:
         # ARRANGE — old coverage format: ClassName.method_name
         context = 'TestClass.test_method'
 
         # ACT
         result = _extract_test_name_from_context(context)
 
-        # ASSERT — must return 'test_method', not 'TestClass'.
-        assert result == 'test_method'
+        # ASSERT — full context preserved (no longer strips to bare function name)
+        assert result == 'TestClass.test_method'
 
     def it_returns_plain_name_unchanged(self) -> None:
         # ARRANGE — bare function name with no separators.

--- a/tests/plugin/test_plugin_pytest_cov_conflict.py
+++ b/tests/plugin/test_plugin_pytest_cov_conflict.py
@@ -169,7 +169,7 @@ def _make_session_finish_mocks(
     gremlin_session = GremlinSession(
         enabled=True,
         gremlins=[mock_gremlin],
-        test_node_ids={'test_foo': 'tests/test_mod.py::test_foo'},
+        test_node_ids={'tests/test_mod.py::test_foo': 'tests/test_mod.py::test_foo'},
     )
 
     return mock_session, gremlin_session
@@ -386,10 +386,10 @@ class DescribeCoverageSQLiteReading:
         with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_coverage_file):
             result = _run_tests_with_coverage(['tests/test_mod.py::test_foo'], tmp_path)
 
-        assert 'test_foo' in result
-        assert 'src/module.py' in result['test_foo']
-        assert 0 in result['test_foo']['src/module.py']
-        assert 1 in result['test_foo']['src/module.py']
+        assert 'tests/test_mod.py::test_foo' in result
+        assert 'src/module.py' in result['tests/test_mod.py::test_foo']
+        assert 0 in result['tests/test_mod.py::test_foo']['src/module.py']
+        assert 1 in result['tests/test_mod.py::test_foo']['src/module.py']
 
     def it_returns_empty_dict_when_coverage_file_absent(self, tmp_path: Path) -> None:
         """When subprocess runs but produces no .coverage file, an empty dict is returned."""
@@ -429,8 +429,8 @@ class DescribeCoverageSQLiteReading:
         with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_multi_row_db):
             result = _run_tests_with_coverage([], tmp_path)
 
-        assert 0 in result['test_foo']['src/module.py']
-        assert 1 in result['test_foo']['src/module.py']
+        assert 0 in result['tests/test_mod.py::test_foo']['src/module.py']
+        assert 1 in result['tests/test_mod.py::test_foo']['src/module.py']
 
     def it_skips_line_bits_rows_with_orphaned_context_or_file_id(self, tmp_path: Path) -> None:
         """line_bits rows whose context_id or file_id are not in their tables are skipped (hits continue)."""
@@ -456,5 +456,5 @@ class DescribeCoverageSQLiteReading:
             result = _run_tests_with_coverage([], tmp_path)
 
         # Only the valid row contributes; orphaned rows are silently skipped
-        assert 'test_bar' in result
-        assert 0 in result['test_bar']['src/module.py']
+        assert 'tests/test_mod.py::test_bar' in result
+        assert 0 in result['tests/test_mod.py::test_bar']['src/module.py']

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.8.0b0"
+version = "1.8.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

Coverage-guided test selection used bare function names as keys. When multiple test files had functions with the same name (common in BDD-style `it_*` naming), only the last one survived in the dict. Tests from other files were silently dropped.

## Changes

- `_extract_test_name_from_context()` now returns the full node ID (`tests/test_foo.py::TestClass::test_bar`) instead of just `test_bar`
- `test_node_ids` keyed by node ID instead of `item.name`
- Updated existing tests for new return values

## Impact

Any project with duplicate test function names across files now gets correct coverage-guided selection. This was the root cause of SayMore's 22 surviving mutants — their `it_*` functions in `test_mutation_kills.py` were being silently dropped.

## Test plan

- [ ] `uv run pytest tests -m small` — 1002 passed
- [ ] `uv run mypy src/pytest_gremlins` — clean

Closes #356

🤖 Generated with [Claude Code](https://claude.ai/claude-code)