### PR TITLE
fix: increase attrs compat timeout for suffix-match overhead

### DIFF
--- a/tests/integration/test_attrs_full.py
+++ b/tests/integration/test_attrs_full.py
@@ -38,7 +38,7 @@ class DescribeAttrsFullCompatibility:
             cwd=str(attrs_checkout),
             capture_output=True,
             text=True,
-            timeout=600,
+            timeout=1200,  # suffix-match fallback (#359) adds overhead; optimize later
             check=False,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.8.0b2"
+version = "1.8.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
Temporary until #359 optimizes the fallback.