### PR TITLE
fix: expand bare names to node IDs in coverage map building

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -189,6 +189,9 @@ class GremlinSession:
             PRIVATE mode.  ``None`` when xdist is not active.
         exclude_patterns: Glob patterns from ``[tool.pytest-gremlins] exclude``
             used to skip matching files during source discovery.
+        test_name_to_node_ids: Reverse index mapping bare function names to
+            their full pytest node IDs.  Built at session setup for O(1)
+            lookup when resolving coverage contexts.
     """
 
     enabled: bool = False
@@ -227,6 +230,7 @@ class GremlinSession:
     max_pardons_pct: float | None = None
     max_pardons: int | None = None
     no_coverage_filter: bool = False
+    test_name_to_node_ids: dict[str, list[str]] = field(default_factory=dict)
 
 
 _gremlin_session: GremlinSession | None = None
@@ -878,6 +882,12 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     normalized_node_ids = _make_node_ids_relative(node_ids, rootdir)
     gremlin_session.test_node_ids = {node_id: node_id for node_id in normalized_node_ids}
 
+    name_to_nodes: dict[str, list[str]] = {}
+    for node_id in normalized_node_ids:
+        func_name = node_id.split('::')[-1]
+        name_to_nodes.setdefault(func_name, []).append(node_id)
+    gremlin_session.test_name_to_node_ids = name_to_nodes
+
     source_files = _discover_source_files(session, gremlin_session)
     gremlin_session.source_files = source_files
 
@@ -1524,6 +1534,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # n
             )
         normalized = _make_node_ids_relative(xdist_ids, rootdir)
         gremlin_session.test_node_ids = {nid: nid for nid in normalized}
+        xdist_name_to_nodes: dict[str, list[str]] = {}
+        for nid in normalized:
+            func_name = nid.split('::')[-1]
+            xdist_name_to_nodes.setdefault(func_name, []).append(nid)
+        gremlin_session.test_name_to_node_ids = xdist_name_to_nodes
         gremlin_session.total_tests = len(normalized)
         logger.debug('pytest_sessionfinish: xdist Phase 2 reconstructed %d test node IDs', len(normalized))
         source_files = _discover_source_files(session, gremlin_session)
@@ -1624,7 +1639,11 @@ def _collect_coverage(gremlin_session: GremlinSession, rootdir: Path) -> None:
     # Pytest node IDs can be absolute paths in some contexts (e.g., pytester)
     relative_node_ids = _make_node_ids_relative(test_node_ids, rootdir)
 
-    coverage_data = _run_tests_with_coverage(relative_node_ids, rootdir)
+    coverage_data = _run_tests_with_coverage(
+        relative_node_ids,
+        rootdir,
+        name_to_node_ids=gremlin_session.test_name_to_node_ids,
+    )
 
     if not coverage_data:
         warnings.warn(
@@ -1662,9 +1681,46 @@ def _collect_coverage(gremlin_session: GremlinSession, rootdir: Path) -> None:
     gremlin_session.prioritized_selector = PrioritizedSelector(collector.coverage_map)
 
 
+def _populate_coverage_from_line_bits(
+    rows: list[tuple[int, int, bytes]],
+    contexts: dict[int, str],
+    files: dict[int, str],
+    name_to_node_ids: dict[str, list[str]] | None,
+    coverage_by_test: dict[str, dict[str, list[int]]],
+) -> None:
+    """Populate coverage_by_test from SQLite line_bits rows.
+
+    Expands bare function names from coverage contexts to full node IDs
+    using the reverse index, so downstream lookups (test selection, cache
+    hashing) can match them against node-ID-keyed dicts.
+    """
+    for file_id, context_id, numbits in rows:
+        if context_id not in contexts or file_id not in files:
+            continue
+
+        context = contexts[context_id]
+        test_name = _extract_test_name_from_context(context)
+        file_path = files[file_id]
+        lines = _decode_numbits(numbits)
+
+        if '::' not in test_name and name_to_node_ids:
+            resolved_names = name_to_node_ids.get(test_name, [test_name])
+        else:
+            resolved_names = [test_name]
+
+        for resolved_name in resolved_names:
+            if resolved_name not in coverage_by_test:
+                coverage_by_test[resolved_name] = {}
+            if file_path not in coverage_by_test[resolved_name]:
+                coverage_by_test[resolved_name][file_path] = []
+            coverage_by_test[resolved_name][file_path].extend(lines)
+
+
 def _run_tests_with_coverage(
     test_node_ids: list[str],
     rootdir: Path,
+    *,
+    name_to_node_ids: dict[str, list[str]] | None = None,
 ) -> dict[str, dict[str, list[int]]]:
     """Run all tests with coverage collection using dynamic contexts.
 
@@ -1675,6 +1731,10 @@ def _run_tests_with_coverage(
     Args:
         test_node_ids: List of pytest node IDs to run.
         rootdir: Root directory of the project.
+        name_to_node_ids: Reverse index mapping bare function names to full
+            node IDs.  When coverage.py records a bare name (old-format
+            ``dynamic_context=test_function``), the map is used to expand it
+            to every matching full node ID so downstream lookups succeed.
 
     Returns:
         Dict mapping test names to their coverage data (file path -> lines).
@@ -1733,22 +1793,13 @@ dynamic_context = test_function
         files = {row[0]: row[1] for row in cursor.fetchall()}
 
         cursor.execute('SELECT file_id, context_id, numbits FROM line_bits')
-        for file_id, context_id, numbits in cursor.fetchall():
-            if context_id not in contexts or file_id not in files:
-                continue
-
-            context = contexts[context_id]
-            test_name = _extract_test_name_from_context(context)
-
-            file_path = files[file_id]
-
-            lines = _decode_numbits(numbits)
-
-            if test_name not in coverage_by_test:
-                coverage_by_test[test_name] = {}
-            if file_path not in coverage_by_test[test_name]:
-                coverage_by_test[test_name][file_path] = []
-            coverage_by_test[test_name][file_path].extend(lines)
+        _populate_coverage_from_line_bits(
+            cursor.fetchall(),
+            contexts,
+            files,
+            name_to_node_ids,
+            coverage_by_test,
+        )
 
         conn.close()
 
@@ -2191,11 +2242,13 @@ def _build_test_hashes_for_gremlin(
             node_id = gremlin_session.test_node_ids.get(simple_name, '')
         if not node_id:
             # Coverage map may use bare function names (old-format dynamic_context)
-            # while test_node_ids is keyed by full node ID.  Search by suffix match.
-            for nid in gremlin_session.test_node_ids:
-                if nid.endswith(('::' + test_name, '::' + test_name.split('.')[-1])):
-                    node_id = nid
-                    break
+            # while test_node_ids is keyed by full node ID.  Use the reverse index
+            # for O(1) lookup instead of O(n) linear suffix scan.
+            candidates = gremlin_session.test_name_to_node_ids.get(test_name, [])
+            if not candidates:
+                candidates = gremlin_session.test_name_to_node_ids.get(test_name.split('.')[-1], [])
+            if candidates:
+                node_id = candidates[0]
 
         if '::' in node_id:
             test_file = node_id.split('::')[0]

--- a/tests/plugin/test_plugin_pytest_cov_conflict.py
+++ b/tests/plugin/test_plugin_pytest_cov_conflict.py
@@ -458,3 +458,111 @@ class DescribeCoverageSQLiteReading:
         # Only the valid row contributes; orphaned rows are silently skipped
         assert 'tests/test_mod.py::test_bar' in result
         assert 0 in result['tests/test_mod.py::test_bar']['src/module.py']
+
+    def it_expands_bare_function_names_to_full_node_ids(self, tmp_path: Path) -> None:
+        """When coverage context uses old format (bare name), expand via reverse index."""
+        numbits = bytes([0x03])  # lines 0 and 1
+
+        def create_bare_name_db(cmd: list[str], **_kwargs: object) -> object:  # noqa: ARG001
+            _write_coverage_sqlite(
+                tmp_path / '.coverage',
+                contexts=[(1, 'test_eq')],  # old format: bare function name
+                files=[(1, 'src/module.py')],
+                line_bits=[(1, 1, numbits)],
+            )
+
+            class FakeResult:
+                returncode = 0
+
+            return FakeResult()
+
+        name_to_node_ids = {
+            'test_eq': [
+                'tests/test_attrs.py::test_eq',
+                'tests/test_other.py::test_eq',
+            ],
+        }
+
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_bare_name_db):
+            result = _run_tests_with_coverage([], tmp_path, name_to_node_ids=name_to_node_ids)
+
+        # Bare name 'test_eq' should be expanded to both full node IDs
+        assert 'test_eq' not in result
+        assert 'tests/test_attrs.py::test_eq' in result
+        assert 'tests/test_other.py::test_eq' in result
+        assert 0 in result['tests/test_attrs.py::test_eq']['src/module.py']
+        assert 0 in result['tests/test_other.py::test_eq']['src/module.py']
+
+    def it_keeps_full_node_ids_unchanged_when_expanding(self, tmp_path: Path) -> None:
+        """When coverage context already has full node IDs, they pass through unchanged."""
+        numbits = bytes([0x01])
+
+        def create_full_node_db(cmd: list[str], **_kwargs: object) -> object:  # noqa: ARG001
+            _write_coverage_sqlite(
+                tmp_path / '.coverage',
+                contexts=[(1, 'tests/test_foo.py::test_bar|run')],
+                files=[(1, 'src/module.py')],
+                line_bits=[(1, 1, numbits)],
+            )
+
+            class FakeResult:
+                returncode = 0
+
+            return FakeResult()
+
+        name_to_node_ids = {'test_bar': ['tests/test_foo.py::test_bar']}
+
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_full_node_db):
+            result = _run_tests_with_coverage([], tmp_path, name_to_node_ids=name_to_node_ids)
+
+        assert 'tests/test_foo.py::test_bar' in result
+        assert 0 in result['tests/test_foo.py::test_bar']['src/module.py']
+
+    def it_falls_back_to_bare_name_when_not_in_reverse_index(self, tmp_path: Path) -> None:
+        """When a bare name has no reverse index entry, it is kept as-is."""
+        numbits = bytes([0x01])
+
+        def create_unknown_bare_db(cmd: list[str], **_kwargs: object) -> object:  # noqa: ARG001
+            _write_coverage_sqlite(
+                tmp_path / '.coverage',
+                contexts=[(1, 'test_unknown')],  # bare name not in index
+                files=[(1, 'src/module.py')],
+                line_bits=[(1, 1, numbits)],
+            )
+
+            class FakeResult:
+                returncode = 0
+
+            return FakeResult()
+
+        name_to_node_ids: dict[str, list[str]] = {}  # empty index
+
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_unknown_bare_db):
+            result = _run_tests_with_coverage([], tmp_path, name_to_node_ids=name_to_node_ids)
+
+        # Falls back to the bare name since reverse index has no entry
+        assert 'test_unknown' in result
+        assert 0 in result['test_unknown']['src/module.py']
+
+    def it_does_not_expand_when_no_reverse_index_provided(self, tmp_path: Path) -> None:
+        """When name_to_node_ids is None (default), bare names pass through unchanged."""
+        numbits = bytes([0x01])
+
+        def create_bare_no_index_db(cmd: list[str], **_kwargs: object) -> object:  # noqa: ARG001
+            _write_coverage_sqlite(
+                tmp_path / '.coverage',
+                contexts=[(1, 'test_bare')],
+                files=[(1, 'src/module.py')],
+                line_bits=[(1, 1, numbits)],
+            )
+
+            class FakeResult:
+                returncode = 0
+
+            return FakeResult()
+
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=create_bare_no_index_db):
+            result = _run_tests_with_coverage([], tmp_path)  # no name_to_node_ids
+
+        assert 'test_bare' in result
+        assert 0 in result['test_bare']['src/module.py']

--- a/tests/plugin/test_reverse_index.py
+++ b/tests/plugin/test_reverse_index.py
@@ -1,0 +1,48 @@
+"""Tests for the reverse index that maps bare function names to full node IDs.
+
+The reverse index replaces the linear suffix-match fallback in
+_build_test_hashes_for_gremlin with O(1) lookups.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pytest_gremlins.plugin import (
+    GremlinSession,
+    _build_test_hashes_for_gremlin,
+)
+
+
+@pytest.mark.small
+class DescribeTestNameToNodeIds:
+    """Tests for the test_name_to_node_ids reverse index on GremlinSession."""
+
+    def it_defaults_to_empty_dict(self) -> None:
+        """A fresh GremlinSession has an empty reverse index."""
+        gs = GremlinSession(enabled=True)
+
+        assert gs.test_name_to_node_ids == {}
+
+
+@pytest.mark.small
+class DescribeBuildTestHashesWithReverseIndex:
+    """Tests for _build_test_hashes_for_gremlin using the reverse index."""
+
+    def it_resolves_bare_function_name_via_reverse_index(self) -> None:
+        """A bare coverage name like 'test_bar' resolves via reverse index."""
+        gs = GremlinSession(
+            enabled=True,
+            test_node_ids={
+                'tests/test_foo.py::test_bar': 'tests/test_foo.py::test_bar',
+            },
+            test_hashes={'tests/test_foo.py': 'hash_abc'},
+            test_name_to_node_ids={
+                'test_bar': ['tests/test_foo.py::test_bar'],
+            },
+        )
+
+        result = _build_test_hashes_for_gremlin(['test_bar'], gs)
+
+        assert 'test_bar' in result
+        assert result['test_bar'] == 'hash_abc'

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.8.0b4"
+version = "1.8.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

Follow-up to #363. The reverse index fixed the O(n) lookup but the coverage map still stored bare function names. When coverage.py's `dynamic_context=test_function` produces bare names like `test_eq`, the map now expands them to ALL matching full node IDs at insertion time.

This fixes the attrs compat 15.6% error rate (86/552 gremlins erroring) where bare names matched the wrong test.

Also extracts `_populate_coverage_from_line_bits` helper to satisfy ruff C901.

## Test plan

- [ ] CI all green
- [ ] Attrs compat < 10% error rate in release pipeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)