### PR TITLE
fix: rsplit on last pipe so parametrize values containing | are not dropped from coverage selection

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -243,9 +243,11 @@ def _extract_test_name_from_context(context: str) -> str:
 
     - **New format** (GremlinContextPlugin): ``{nodeid}|{when}``
       e.g. ``tests/test_foo.py::TestClass::test_bar|run``
-      Returns the full node ID (everything before ``|``), preserving the
-      file path and class qualifiers so that tests with the same function
-      name in different files are distinguishable.
+      Returns the full node ID (everything before the *last* ``|``),
+      preserving the file path and class qualifiers so that tests with the
+      same function name in different files are distinguishable.  The split
+      uses ``rsplit`` so that parametrize values containing ``|`` (e.g.
+      ``test_add[a|b]|run``) are preserved intact.
 
     - **Old format** (coverage dynamic_context=test_function):
       e.g. ``test_bar`` or ``TestClass.test_method``
@@ -271,9 +273,11 @@ def _extract_test_name_from_context(context: str) -> str:
         'TestClass.test_method'
         >>> _extract_test_name_from_context('tests/test_foo.py::test_func')
         'tests/test_foo.py::test_func'
+        >>> _extract_test_name_from_context('tests/test_foo.py::test_add[a|b]|run')
+        'tests/test_foo.py::test_add[a|b]'
     """
     if '|' in context:
-        return context.split('|', maxsplit=1)[0]
+        return context.rsplit('|', maxsplit=1)[0]
     return context
 
 

--- a/tests/plugin/test_context_parsing.py
+++ b/tests/plugin/test_context_parsing.py
@@ -64,3 +64,28 @@ class DescribeExtractTestNameFromContext:
         """Old format 'path::test_func' (no pipe) passes through unchanged."""
         result = _extract_test_name_from_context('tests/test_foo.py::test_func')
         assert result == 'tests/test_foo.py::test_func'
+
+    def it_strips_only_the_trailing_phase_suffix_when_param_contains_pipe(self) -> None:
+        """Parametrize values containing '|' must not be split mid-name.
+
+        pytest node IDs like ``test_add[a|b-c]`` embed ``|`` inside the
+        bracket expression.  Only the trailing ``|{when}`` suffix should be
+        stripped — not any ``|`` inside the brackets.
+        """
+        result = _extract_test_name_from_context('tests/test_calc.py::test_add[a|b-c]|run')
+        assert result == 'tests/test_calc.py::test_add[a|b-c]'
+
+    def it_handles_multiple_pipes_in_param_value(self) -> None:
+        """Multiple ``|`` characters inside brackets are all preserved."""
+        result = _extract_test_name_from_context('tests/test_calc.py::test_add[a|b-c-a|bc]|run')
+        assert result == 'tests/test_calc.py::test_add[a|b-c-a|bc]'
+
+    def it_strips_setup_phase_when_param_contains_pipe(self) -> None:
+        """The ``|setup`` suffix is stripped even when param value contains ``|``."""
+        result = _extract_test_name_from_context('tests/test_calc.py::test_add[a|b]|setup')
+        assert result == 'tests/test_calc.py::test_add[a|b]'
+
+    def it_strips_teardown_phase_when_param_contains_pipe(self) -> None:
+        """The ``|teardown`` suffix is stripped even when param value contains ``|``."""
+        result = _extract_test_name_from_context('tests/test_calc.py::test_add[a|b]|teardown')
+        assert result == 'tests/test_calc.py::test_add[a|b]'


### PR DESCRIPTION
Closes #387.

## The bug

Coverage-guided test selection silently dropped tests whose parametrize values contained a `|`, producing **false-positive survivors** (mutants reported as surviving that the suite actually kills). `--gremlin-no-coverage-filter` masked it by skipping selection entirely.

## Root cause

`_extract_test_name_from_context` stripped the `|{when}` phase suffix with `split('|', maxsplit=1)[0]`. For a parametrized node ID like `tests/test_calc.py::test_add[a|b-c-a|bc]|run`, splitting on the **first** pipe truncated it to `tests/test_calc.py::test_add[a` — which matched nothing in the node-ID index, so those tests were never selected as covering the mutated line. The mutant ran against a subset, survived, and the wrong result was cached.

The reported **run-to-run shift** in survivors maps to cache-invalidation events (each invalidation re-caches the same wrong selection), not randomness — which is why it looked nondeterministic. This is distinct from the duplicate-name theory in `COVERAGE_SELECTION_BUG.md` and from #356/#367/#368/#376/#377: it needs no duplicate names and doesn't involve the coverage-stopped path.

## Fix

One character: `split('|', maxsplit=1)` → `rsplit('|', maxsplit=1)`. The `|{when}` suffix is always last (`when` ∈ {setup, run, teardown}, none contain `|` — invariant enforced at construction in `context_plugin.py`), so splitting from the right recovers the full node ID and preserves pipes inside parametrize brackets.

## Tests

New `tests/plugin/test_context_parsing.py`: pipe-in-param, multiple pipes (kills a `maxsplit` mutation too), all three phases, and no-pipe passthrough. Adversarial QA confirmed the param tests fail under the reverted `split` (contract-proving, not tautologies).

## Verification
1454 passed / 2 skipped · mypy clean · ruff clean · doctests pass · adversarial QA pass (0 bugs) · church (python + test purists) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)