### PR TITLE
cleanup: scope cold-run coverage to gremlin source files

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1781,12 +1781,14 @@ def _run_tests_with_coverage(
             ``dynamic_context=test_function``), the map is used to expand it
             to every matching full node ID so downstream lookups succeed.
         coverage_include: Optional list of file paths to scope coverage
-            tracing to.  When non-empty, the generated coveragerc uses an
-            ``include =`` list of these paths instead of ``source = .``, so
-            coverage.py only traces the gremlin source files rather than the
-            entire tree.  Downstream post-processing discards coverage for
-            non-gremlin files anyway, so narrowing scope here avoids wasted
-            tracing and SQLite I/O without changing the resulting coverage map.
+            tracing to.  When non-empty and contains no glob-special characters
+            (``*?[]``), the generated coveragerc uses an ``include =`` list of
+            these paths instead of ``source = .``, so coverage.py only traces
+            the gremlin source files rather than the entire tree. If any path
+            contains a glob-special character, falls back to ``source = .``
+            (since coverage.py interprets ``include`` entries as fnmatch globs).
+            Downstream post-processing discards non-gremlin coverage, so narrowing
+            scope avoids wasted tracing and SQLite I/O without changing the result.
 
     Returns:
         Dict mapping test names to their coverage data (file path -> lines).
@@ -1800,7 +1802,7 @@ def _run_tests_with_coverage(
     # escaped for coverage.py's tokenizer. When any glob-special char is
     # present, fall back to source = . and rely on post-processing filtering
     # (lines ~1698-1716) to discard non-gremlin coverage.
-    has_glob_special_chars = coverage_include and any(ch in p for p in coverage_include for ch in '*?[]')
+    has_glob_special_chars = any(ch in p for p in (coverage_include or []) for ch in '*?[]')
     if coverage_include and not has_glob_special_chars:
         include_lines = '\n'.join(f'    {path}' for path in coverage_include)
         coveragerc_content = f'[run]\ninclude =\n{include_lines}\n'

--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1680,10 +1680,13 @@ def _collect_coverage(gremlin_session: GremlinSession, rootdir: Path) -> None:
     # Pytest node IDs can be absolute paths in some contexts (e.g., pytester)
     relative_node_ids = _make_node_ids_relative(test_node_ids, rootdir)
 
+    coverage_include = sorted({str(Path(gremlin.file_path).resolve()) for gremlin in gremlin_session.gremlins})
+
     coverage_data = _run_tests_with_coverage(
         relative_node_ids,
         rootdir,
         name_to_node_ids=gremlin_session.test_name_to_node_ids,
+        coverage_include=coverage_include or None,
     )
 
     if not coverage_data:
@@ -1762,6 +1765,7 @@ def _run_tests_with_coverage(
     rootdir: Path,
     *,
     name_to_node_ids: dict[str, list[str]] | None = None,
+    coverage_include: list[str] | None = None,
 ) -> dict[str, dict[str, list[int]]]:
     """Run all tests with coverage collection using dynamic contexts.
 
@@ -1776,6 +1780,13 @@ def _run_tests_with_coverage(
             node IDs.  When coverage.py records a bare name (old-format
             ``dynamic_context=test_function``), the map is used to expand it
             to every matching full node ID so downstream lookups succeed.
+        coverage_include: Optional list of file paths to scope coverage
+            tracing to.  When non-empty, the generated coveragerc uses an
+            ``include =`` list of these paths instead of ``source = .``, so
+            coverage.py only traces the gremlin source files rather than the
+            entire tree.  Downstream post-processing discards coverage for
+            non-gremlin files anyway, so narrowing scope here avoids wasted
+            tracing and SQLite I/O without changing the resulting coverage map.
 
     Returns:
         Dict mapping test names to their coverage data (file path -> lines).
@@ -1784,9 +1795,11 @@ def _run_tests_with_coverage(
     coverage_db_path.unlink(missing_ok=True)
 
     coveragerc_path = rootdir / '.coveragerc.gremlins'
-    coveragerc_content = """[run]
-source = .
-"""
+    if coverage_include:
+        include_lines = '\n'.join(f'    {path}' for path in coverage_include)
+        coveragerc_content = f'[run]\ninclude =\n{include_lines}\n'
+    else:
+        coveragerc_content = '[run]\nsource = .\n'
     coveragerc_path.write_text(coveragerc_content)
 
     cmd = [

--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1795,7 +1795,13 @@ def _run_tests_with_coverage(
     coverage_db_path.unlink(missing_ok=True)
 
     coveragerc_path = rootdir / '.coveragerc.gremlins'
-    if coverage_include:
+    # coverage.py's include directive interprets paths as glob patterns.
+    # Paths with literal glob-special characters (*?[]) cannot be safely
+    # escaped for coverage.py's tokenizer. When any glob-special char is
+    # present, fall back to source = . and rely on post-processing filtering
+    # (lines ~1698-1716) to discard non-gremlin coverage.
+    has_glob_special_chars = coverage_include and any(ch in p for p in coverage_include for ch in '*?[]')
+    if coverage_include and not has_glob_special_chars:
         include_lines = '\n'.join(f'    {path}' for path in coverage_include)
         coveragerc_content = f'[run]\ninclude =\n{include_lines}\n'
     else:

--- a/tests/coverage_module/test_coverage_include_glob_special_chars.py
+++ b/tests/coverage_module/test_coverage_include_glob_special_chars.py
@@ -1,0 +1,52 @@
+"""Adversarial test: coverage_include must match source paths with glob-special chars.
+
+The cold coverage run writes the resolved gremlin source paths into the
+``[run] include =`` section of the generated coveragerc.  coverage.py treats
+``include`` entries as fnmatch globs, so a path containing ``[``/``]``/``?``/``*``
+is interpreted as a glob pattern and fails to match its own literal path.
+
+When that happens the gremlin source file gets NO coverage -> no covering tests
+are selected -> the gremlin survives falsely.  This is the #387 false-survivor
+class.  The old ``source = .`` behavior did not have this problem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from pytest_gremlins.plugin import _run_tests_with_coverage
+
+
+@pytest.mark.medium
+class DescribeCoverageIncludeGlobSpecialChars:
+    """coverage_include with glob-special chars in the path."""
+
+    def it_records_coverage_for_source_in_bracketed_directory(self) -> None:
+        """A gremlin source file in a dir containing ``[`` still gets coverage."""
+        root = Path(tempfile.mkdtemp())
+        srcdir = root / 'mod[v2]'
+        srcdir.mkdir()
+        (srcdir / '__init__.py').write_text('')
+        src = srcdir / 'calc.py'
+        src.write_text('def add(a, b):\n    return a + b\n')
+        test = root / 'test_calc.py'
+        test.write_text(
+            'import sys\n'
+            f'sys.path.insert(0, {str(root)!r})\n'
+            'from importlib import import_module\n'
+            "m = import_module('mod[v2].calc')\n"
+            'def test_add():\n'
+            '    assert m.add(1, 2) == 3\n'
+        )
+
+        include = [str(src.resolve())]
+        data = _run_tests_with_coverage(['test_calc.py'], root, coverage_include=include)
+
+        covered_files = {Path(f).resolve() for file_cov in data.values() for f in file_cov}
+        assert src.resolve() in covered_files, (
+            f'Source file in bracketed dir got no coverage. covered_files={covered_files}. '
+            'coverage_include glob failed to match the literal path -> false survivor.'
+        )

--- a/tests/coverage_module/test_coverage_subprocess_command.py
+++ b/tests/coverage_module/test_coverage_subprocess_command.py
@@ -7,11 +7,18 @@ for full node ID contexts instead of dynamic_context=test_function.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 import pytest
 
-from pytest_gremlins.plugin import _run_tests_with_coverage
+from pytest_gremlins.plugin import (
+    GremlinSession,
+    _collect_coverage,
+    _run_tests_with_coverage,
+)
 
 
 @pytest.mark.medium
@@ -60,3 +67,68 @@ class DescribeRunTestsWithCoverageCommand:
 
         assert captured_content, 'coveragerc was not written before subprocess.run'
         assert 'dynamic_context' not in captured_content[0]
+
+    def it_uses_source_dot_when_no_coverage_include(self, tmp_path: Path) -> None:
+        """Without coverage_include, the coveragerc keeps the source = . default."""
+        captured_content: list[str] = []
+
+        def capture_cmd(*_args: object, **_kwargs: object) -> None:
+            coveragerc_path = tmp_path / '.coveragerc.gremlins'
+            if coveragerc_path.exists():
+                captured_content.append(coveragerc_path.read_text())
+
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=capture_cmd):
+            _run_tests_with_coverage(['tests/test_a.py::test_one'], tmp_path)
+
+        assert captured_content
+        assert 'source = .' in captured_content[0]
+        assert 'include =' not in captured_content[0]
+
+    def it_writes_include_section_when_coverage_include_provided(self, tmp_path: Path) -> None:
+        """With coverage_include, the coveragerc lists those paths under include and drops source = ."""
+        captured_content: list[str] = []
+
+        def capture_cmd(*_args: object, **_kwargs: object) -> None:
+            coveragerc_path = tmp_path / '.coveragerc.gremlins'
+            if coveragerc_path.exists():
+                captured_content.append(coveragerc_path.read_text())
+
+        include = ['/abs/src/foo.py', '/abs/src/bar.py']
+        with patch('pytest_gremlins.plugin.subprocess.run', side_effect=capture_cmd):
+            _run_tests_with_coverage(['tests/test_a.py::test_one'], tmp_path, coverage_include=include)
+
+        assert captured_content
+        content = captured_content[0]
+        assert 'source = .' not in content
+        assert 'include =' in content
+        assert '/abs/src/foo.py' in content
+        assert '/abs/src/bar.py' in content
+
+
+@pytest.mark.medium
+class DescribeCollectCoverageScoping:
+    """_collect_coverage scopes coverage to the gremlin source files."""
+
+    def it_passes_resolved_gremlin_source_files_as_coverage_include(self, tmp_path: Path) -> None:
+        """_collect_coverage forwards the resolved, sorted gremlin file paths as coverage_include."""
+        source_file = tmp_path / 'mymodule.py'
+        source_file.write_text('x = 1\n')
+
+        gremlin_a = MagicMock(spec=['file_path'])
+        gremlin_a.file_path = str(source_file)
+        gremlin_b = MagicMock(spec=['file_path'])
+        gremlin_b.file_path = str(source_file)
+
+        gs = GremlinSession(enabled=True)
+        gs.gremlins = [gremlin_a, gremlin_b]
+
+        captured: dict[str, object] = {}
+
+        def fake_run(*_args: object, **kwargs: object) -> dict[str, dict[str, list[int]]]:
+            captured.update(kwargs)
+            return {'tests/test_x.py::test_x': {str(source_file): [1]}}
+
+        with patch('pytest_gremlins.plugin._run_tests_with_coverage', side_effect=fake_run):
+            _collect_coverage(gs, tmp_path)
+
+        assert captured['coverage_include'] == [str(source_file.resolve())]


### PR DESCRIPTION
Closes #422.

Scopes the cold coverage run to gremlin source files (`[run] include = <resolved gremlin paths>`) instead of `source = .`, since the post-processing already discards coverage for every non-gremlin file. **Ships as cleanup, not a perf win** — benchmarked ~1% on attrs (within noise; the cold-coverage step is dominated by test-body execution, not tracing). Traced files 51→13, coverage DB ~25% smaller.

## Correctness (the important part)
Adversarial QA caught that coverage.py treats `include =` entries as **fnmatch globs**, so a gremlin path with `*?[]` (e.g. `mod[v2]/`) would fail to match → false survivor (#387 class). Fix: fall back to `source = .` whenever any gremlin path contains a glob-special char; use scoped `include =` only for glob-clean paths. The predicate `*?[]` was verified an exhaustive superset against coverage.py 7.14.1's matcher. The `source = .` fallback preserves correctness (post-processing still filters).

## Verification
1476 passed / 2 skipped · mypy clean · ruff clean · adversarial QA pass (the bracketed-dir test is mutation-verified to pin the fallback) · python + test purists clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)