### PR TITLE
chore: sync uv.lock self-version to 1.9.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1642,7 +1642,7 @@ wheels = [
 
 [[package]]
 name = "pytest-gremlins"
-version = "1.8.1"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
## Summary

The v1.9.0 release bumped `pyproject.toml` (and the git tag) to `1.9.0`, but the self-referential `pytest-gremlins` entry in `uv.lock` was never regenerated — it stayed pinned at `version = "1.8.1"`.

Every `uv run` invocation detects the mismatch and rewrites `uv.lock` to `1.9.0`, dirtying the working tree. The `ruff-check-all` pre-push hook runs `uv run ruff check src tests`, triggers that rewrite, sees "files were modified by this hook", and **aborts the push** — from every branch in the repo.

## Fix

Regenerated `uv.lock` via `uv lock` so the committed lockfile matches `pyproject.toml` (`1.9.0`). One-line change: `pytest-gremlins` `1.8.1 → 1.9.0`.

## Why this is safe and self-unblocking

- Lockfile-only, no dependency version changes (only the self-version line moves).
- Once the committed `uv.lock` says `1.9.0`, the hook's `uv run` finds it correct, modifies nothing, and the tree stays clean.

Release-hygiene follow-up to the v1.9.0 cut.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
