### PR TITLE
feat(reporting): selected-test column + sonarqube error diagnostics

### DIFF
--- a/docs/guide/reports.md
+++ b/docs/guide/reports.md
@@ -128,6 +128,7 @@ The HTML report includes:
 | Operator | Operator that created the gremlin |
 | Description | Human-readable mutation description |
 | Status | `zapped`, `survived`, `timeout`, or `error` |
+| Selected test | The test that killed the gremlin, or every test the coverage-based selector ran, or `—` if none |
 
 **Status Color Coding:**
 
@@ -180,6 +181,7 @@ The HTML report includes:
                     <th>Operator</th>
                     <th>Description</th>
                     <th>Status</th>
+                    <th>Selected test</th>
                 </tr>
             </thead>
             <tbody>
@@ -189,6 +191,7 @@ The HTML report includes:
                     <td>comparison</td>
                     <td>>= -> ></td>
                     <td class="status-survived">survived</td>
+                    <td>tests/test_auth.py::test_login_validates_age</td>
                 </tr>
                 <!-- More rows... -->
             </tbody>

--- a/docs/guide/reports.md
+++ b/docs/guide/reports.md
@@ -743,7 +743,7 @@ After uploading to Stryker Dashboard, add this badge to your README:
 
 ### SonarQube Export
 
-SonarQube can import surviving mutants as [external issues](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/).
+SonarQube can import surviving mutants and errored gremlins as [external issues](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/).
 
 #### Using SonarQubeExporter
 
@@ -777,15 +777,18 @@ sonar-scanner \
 
 #### What Gets Imported
 
-Only **survived** mutants are imported as issues:
+**Survived** mutants are always imported as issues. **Errored** gremlins are also
+imported, but only when they captured diagnostic output (`error_output`), so you
+can see why a gremlin failed to run rather than whether it survived:
 
-| Field | Value |
-|-------|-------|
-| Engine ID | `pytest-gremlins` |
-| Rule ID | `mutant-survived-{operator}` |
-| Severity | `MAJOR` (configurable) |
-| Type | `CODE_SMELL` |
-| Effort | `10 minutes` (configurable) |
+| Field | Survived | Errored |
+|-------|----------|---------|
+| Engine ID | `pytest-gremlins` | `pytest-gremlins` |
+| Rule ID | `mutant-survived-{operator}` | `mutant-error-{operator}` |
+| Severity | `MAJOR` (configurable) | `MAJOR` (configurable) |
+| Type | `CODE_SMELL` | `CODE_SMELL` |
+| Effort | `10 minutes` (configurable) | `10 minutes` (configurable) |
+| Message | `Mutant survived: {description}` | `Mutant errored: {error_output}` (truncated to 500 chars) |
 
 #### GitHub Actions for SonarQube
 

--- a/src/pytest_gremlins/reporting/html.py
+++ b/src/pytest_gremlins/reporting/html.py
@@ -890,6 +890,7 @@ class HtmlReporter:
                     <th scope="col">Operator</th>
                     <th scope="col">Description</th>
                     <th scope="col">Status</th>
+                    <th scope="col">Selected test</th>
                 </tr>
             </thead>
             <tbody>
@@ -903,6 +904,7 @@ class HtmlReporter:
         gremlin = result.gremlin
         status_class = f'status-{result.status.value}'
         diff_html = self._render_diff_panel(gremlin)
+        selected_test_html = self._render_selected_test(result)
         return f"""
                 <tr>
                     <td>
@@ -913,7 +915,25 @@ class HtmlReporter:
                     <td>{self._escape_html(gremlin.operator_name)}</td>
                     <td>{self._escape_html(gremlin.description)}</td>
                     <td class="{status_class}">{result.status.value}</td>
+                    <td>{selected_test_html}</td>
                 </tr>"""
+
+    def _render_selected_test(self, result: GremlinResult) -> str:
+        """Render the killing test, or the list of selected tests, for a result.
+
+        Args:
+            result: The GremlinResult to extract test information from.
+
+        Returns:
+            HTML-escaped killing test name when present; otherwise a
+            comma-separated, HTML-escaped list of selected test node IDs;
+            an em dash when neither is available.
+        """
+        if result.killing_test:
+            return self._escape_html(result.killing_test)
+        if result.selected_tests:
+            return self._escape_html(', '.join(result.selected_tests))
+        return '—'
 
     def _render_diff_panel(self, gremlin: Gremlin) -> str:
         """Render a collapsible side-by-side diff panel for a gremlin.

--- a/src/pytest_gremlins/reporting/sonarqube_export.py
+++ b/src/pytest_gremlins/reporting/sonarqube_export.py
@@ -1,7 +1,8 @@
 """SonarQube generic issue exporter for mutation testing results.
 
-Exports surviving mutants as external issues that can be imported into
-SonarQube using the sonar.externalIssuesReportPaths parameter.
+Exports surviving mutants, and gremlins that errored with diagnostic
+output, as external issues that can be imported into SonarQube using
+the sonar.externalIssuesReportPaths parameter.
 
 See: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/
 """
@@ -27,8 +28,10 @@ if TYPE_CHECKING:
 class SonarQubeExporter:
     """Exporter that produces SonarQube generic issue format JSON.
 
-    Only surviving mutants are exported as issues since they represent
-    gaps in test coverage that SonarQube should track.
+    Surviving mutants are exported as issues since they represent gaps
+    in test coverage that SonarQube should track. Errored gremlins are
+    also exported, but only when they captured diagnostic output, so
+    SonarQube surfaces why a gremlin failed to run rather than survived.
 
     Usage with SonarQube:
         sonar-scanner -Dsonar.externalIssuesReportPaths=mutation-sonar.json
@@ -86,13 +89,38 @@ class SonarQubeExporter:
         Returns:
             Dictionary in SonarQube generic issue format.
         """
-        issues = [
-            self._build_issue(result) for result in score.results if result.status == GremlinResultStatus.SURVIVED
-        ]
+        issues = [self._build_issue(result) for result in score.results if self._is_exportable(result)]
         return {'issues': issues}
 
+    def _is_exportable(self, result: GremlinResult) -> bool:
+        """Check whether a result should be exported as a SonarQube issue.
+
+        Args:
+            result: The GremlinResult to check.
+
+        Returns:
+            True for survived mutants, and for errored mutants that captured
+            diagnostic output; false otherwise.
+        """
+        if result.status == GremlinResultStatus.SURVIVED:
+            return True
+        return result.status == GremlinResultStatus.ERROR and bool(result.error_output)
+
     def _build_issue(self, result: GremlinResult) -> SonarIssue:
-        """Build a single issue entry for a surviving mutant.
+        """Build a single issue entry for a survived or errored mutant.
+
+        Args:
+            result: The GremlinResult to convert.
+
+        Returns:
+            Dictionary representing this issue.
+        """
+        if result.status == GremlinResultStatus.ERROR:
+            return self._build_error_issue(result)
+        return self._build_survived_issue(result)
+
+    def _build_survived_issue(self, result: GremlinResult) -> SonarIssue:
+        """Build an issue entry for a surviving mutant.
 
         Args:
             result: The GremlinResult to convert.
@@ -115,6 +143,38 @@ class SonarQubeExporter:
                     'startLine': gremlin.line_number,
                 },
                 'message': f'Mutant survived: {gremlin.description}',
+            },
+        }
+
+    def _build_error_issue(self, result: GremlinResult) -> SonarIssue:
+        """Build an issue entry for a gremlin that errored during execution.
+
+        Truncates error_output to 500 chars (matching StrykerExporter's
+        statusReason truncation) to keep the JSON report size reasonable
+        when many gremlins error.
+
+        Args:
+            result: The GremlinResult to convert.
+
+        Returns:
+            Dictionary representing this issue.
+        """
+        gremlin = result.gremlin
+        file_path = self._normalize_path(gremlin.file_path)
+        error_excerpt = result.error_output[:500]
+
+        return {
+            'engineId': 'pytest-gremlins',
+            'ruleId': f'mutant-error-{gremlin.operator_name}',
+            'severity': self._severity,
+            'type': 'CODE_SMELL',
+            'effortMinutes': self._effort_minutes,
+            'primaryLocation': {
+                'filePath': file_path,
+                'textRange': {
+                    'startLine': gremlin.line_number,
+                },
+                'message': f'Mutant errored: {error_excerpt}',
             },
         }
 

--- a/tests/reporting/test_html.py
+++ b/tests/reporting/test_html.py
@@ -132,6 +132,49 @@ class DescribeHtmlReporterContent:
         assert 'survived' in html.lower()
 
 
+@pytest.mark.small
+class DescribeHtmlReporterSelectedTests:
+    """Tests for showing the selected/killing test per mutant. References: #414."""
+
+    def it_shows_the_killing_test_for_a_zapped_gremlin(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.ZAPPED,
+                killing_test='tests/test_auth.py::test_login_validates_age',
+            ),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert 'tests/test_auth.py::test_login_validates_age' in html
+
+    def it_shows_all_selected_tests_for_a_survivor_with_no_killing_test(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.SURVIVED,
+                selected_tests=['tests/test_a.py::test_one', 'tests/test_b.py::test_two'],
+            ),
+        ]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert 'tests/test_a.py::test_one' in html
+        assert 'tests/test_b.py::test_two' in html
+
+    def it_shows_a_placeholder_when_no_test_was_selected(self, make_result):
+        results = [make_result(GremlinResultStatus.SURVIVED)]
+        score = MutationScore.from_results(results)
+        reporter = HtmlReporter()
+
+        html = reporter.to_html(score)
+
+        assert '—' in html
+
+
 @pytest.mark.medium
 class DescribeHtmlReporterFileOutput:
     """Tests for writing HTML to file."""
@@ -1079,7 +1122,7 @@ class DescribeHtmlReporterA11y:
         th_count = table_html.count('<th>')
         scope_col_count = table_html.count('scope="col"')
         assert th_count == 0
-        assert scope_col_count == 5
+        assert scope_col_count == 6
 
 
 @pytest.mark.medium

--- a/tests/reporting/test_sonarqube_export.py
+++ b/tests/reporting/test_sonarqube_export.py
@@ -230,3 +230,42 @@ class DescribeSonarQubeExporterProjectRoot:
         issue = data['issues'][0]
 
         assert issue['primaryLocation']['filePath'] == 'src/auth.py'
+
+
+@pytest.mark.small
+class DescribeSonarQubeExporterErrorOutput:
+    """Tests for surfacing error_output as issues. References: #337."""
+
+    def it_exports_an_issue_for_an_errored_gremlin_with_error_output(self, make_result):
+        results = [
+            make_result(
+                GremlinResultStatus.ERROR,
+                error_output='ImportError: No module named foo',
+            ),
+        ]
+        score = MutationScore.from_results(results)
+        exporter = SonarQubeExporter()
+
+        data = json.loads(exporter.to_json(score))
+
+        assert len(data['issues']) == 1
+        assert 'ImportError: No module named foo' in data['issues'][0]['primaryLocation']['message']
+
+    def it_omits_an_issue_for_an_errored_gremlin_with_no_error_output(self, make_result):
+        results = [make_result(GremlinResultStatus.ERROR, error_output='')]
+        score = MutationScore.from_results(results)
+        exporter = SonarQubeExporter()
+
+        data = json.loads(exporter.to_json(score))
+
+        assert len(data['issues']) == 0
+
+    def it_truncates_error_output_to_500_characters(self, make_result):
+        results = [make_result(GremlinResultStatus.ERROR, error_output='x' * 1000)]
+        score = MutationScore.from_results(results)
+        exporter = SonarQubeExporter()
+
+        data = json.loads(exporter.to_json(score))
+        message = data['issues'][0]['primaryLocation']['message']
+
+        assert len(message) == len('Mutant errored: ') + 500


### PR DESCRIPTION
## Summary

Two reporting enrichments (both render-only — the data already lived on `GremlinResult`):

### #414 — Selected-test column in the HTML report
Adds a "Selected test" column to the HTML results table showing `killing_test` when present, else the joined `selected_tests`, else an em dash. Lets a reader see *which* test was run against each mutant directly in the report.

### #337 — Error diagnostics in the SonarQube export
`SonarQubeExporter` now exports errored gremlins (status `ERROR` with non-empty `error_output`) as `CODE_SMELL` issues (rule `mutant-error-{operator}`), message truncated to 500 chars — matching Stryker's existing truncation. Errored results with empty `error_output` are still excluded. Investigation confirmed the console, HTML, JSON, and Stryker formats already surfaced `error_output`; SonarQube was the only gap.

## Testing

- `DescribeHtmlReporterSelectedTests` (HTML column) and `DescribeSonarQubeExporterErrorOutput` (Sonar issues, empty-output exclusion, 500-char truncation) added.
- Adversarial QA gauntlet ran 9 probes across HTML escaping, empty/None handling, Sonar truncation boundaries (500/501, multi-byte), and Sonar schema conformance — **0 bugs found**; the new HTML cell uses the same `_escape_html` as sibling cells, truncation slices by code points, and the Sonar error issue is schema-identical to the survived-mutant issue.
- `uv run pytest tests -m small` → 1066 passed; mypy clean; ruff clean.

## Scope note

Issue #337's Gherkin references a `--gremlin-error-detail=N` CLI flag that does not exist in the codebase (the console reporter always shows errors when present). That flag is out of scope here and can be a follow-up if still desired.

Closes #414
Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)
