### PR TITLE
test+fix: coverage addopts follow-ups from #436 review (#444/#445/#446)

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1787,6 +1787,16 @@ _COV_FLAG_ONLY_OPTS = frozenset(
     }
 )
 
+# ``--cov`` alone takes an *optional* value (pytest-cov defines it with
+# ``nargs='?'``): a bare ``--cov`` immediately followed by another option has no
+# value to consume, so the dash-prefix heuristic below only applies to this one
+# option. Every other value-taking cov option (``--cov-report``,
+# ``--cov-fail-under``, ``--cov-precision``, etc.) *requires* its value and must
+# consume the next token unconditionally -- even one that happens to start with
+# ``-`` (e.g. ``--cov-fail-under -1``) -- or it silently leaks into the
+# re-injected addopts string as a stray, unrelated-looking token (issue #446).
+_COV_OPTIONAL_VALUE_OPTS = frozenset({'--cov'})
+
 
 def _is_cov_addopt(token: str) -> bool:
     """Return True if ``token`` is a pytest-cov option.
@@ -1812,8 +1822,11 @@ def _addopts_without_cov(raw_addopts: list[str]) -> str:
 
     Only the ``--cov*`` / ``--no-cov*`` option family is stripped. A cov option written
     with a space-separated value (``--cov-report term``, ``--cov-precision 2``) has its
-    value token dropped as well; the known value-less switches in
-    ``_COV_FLAG_ONLY_OPTS`` keep their following token, and inline forms
+    value token dropped as well: required-value options (everything except ``--cov``
+    itself and the known value-less switches in ``_COV_FLAG_ONLY_OPTS``) consume their
+    following token unconditionally, even one that starts with ``-``
+    (``--cov-fail-under -1``); ``--cov``'s optional value is only dropped when the
+    following token doesn't itself look like an option. Inline forms
     (``--cov-report=term``) are self-contained. The result is a single string suitable
     for ``-o addopts=<...>``.
 
@@ -1829,16 +1842,13 @@ def _addopts_without_cov(raw_addopts: list[str]) -> str:
         token = raw_addopts[index]
         index += 1
         if _is_cov_addopt(token):
-            # A value-taking cov option written without an inline ``=`` consumes the
-            # next token as its value; drop that too — unless this is a known value-less
-            # switch or the next token is itself an option.
-            if (
-                '=' not in token
-                and token not in _COV_FLAG_ONLY_OPTS
-                and index < count
-                and not raw_addopts[index].startswith('-')
-            ):
-                index += 1
+            has_no_inline_value = '=' not in token
+            is_value_taking = token not in _COV_FLAG_ONLY_OPTS
+            has_next_token = index < count
+            if has_no_inline_value and is_value_taking and has_next_token:
+                next_looks_like_option = raw_addopts[index].startswith('-')
+                if token not in _COV_OPTIONAL_VALUE_OPTS or not next_looks_like_option:
+                    index += 1
             continue
         kept.append(token)
     return ' '.join(shlex.quote(token) for token in kept)

--- a/tests/plugin/test_plugin_addopts_preserve.py
+++ b/tests/plugin/test_plugin_addopts_preserve.py
@@ -13,6 +13,7 @@ See: https://github.com/mikelane/pytest-gremlins/issues/113
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -180,3 +181,57 @@ class DescribePytestConfigureStoresPreservedAddopts:
         pytest_configure(config)  # type: ignore[arg-type]
 
         assert _get_session().preserved_addopts == '--import-mode=importlib'
+
+
+@pytest.mark.medium
+class DescribeReinjectedAddoptsHonoredByRealPytest:
+    """Regression lock for #424: a real pytest subprocess honors ``-o addopts=<...>``.
+
+    Every other test in this module stubs ``subprocess.run`` and asserts on the
+    constructed command string, so none of them prove that pytest's own
+    ``shlex.split`` of the injected ini value actually re-enables the option at
+    runtime. This spawns a real subprocess against a throwaway project with
+    duplicate test basenames across packages -- something the default (prepend)
+    import mode cannot collect, and ``--import-mode=importlib`` can -- so the
+    test result itself is proof the re-injected addopts took effect.
+    """
+
+    @staticmethod
+    def _write_duplicate_basename_project(rootdir: Path) -> None:
+        for package in ('package_a', 'package_b'):
+            package_dir = rootdir / package
+            package_dir.mkdir()
+            (package_dir / 'test_shared_name.py').write_text('def test_it_passes():\n    assert True\n')
+
+    def it_collects_duplicate_basenames_when_importlib_mode_is_preserved(self, tmp_path: Path) -> None:
+        self._write_duplicate_basename_project(tmp_path)
+        preserved_addopts = _addopts_without_cov(['--cov=mypkg', '--import-mode=importlib'])
+        cmd = _build_test_command(None, preserved_addopts)
+
+        result = subprocess.run(  # Intentional: exercises the real subprocess boundary
+            cmd,
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def it_fails_the_same_collection_when_addopts_are_cleared(self, tmp_path: Path) -> None:
+        """Negative control: without re-injection, pytest's default import mode cannot collect."""
+        self._write_duplicate_basename_project(tmp_path)
+        cmd = _build_test_command(None, '')
+
+        result = subprocess.run(  # Intentional: exercises the real subprocess boundary
+            cmd,
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        assert 'error during collection' in result.stdout

--- a/tests/plugin/test_plugin_addopts_preserve.py
+++ b/tests/plugin/test_plugin_addopts_preserve.py
@@ -95,6 +95,22 @@ class DescribeAddoptsWithoutCov:
         result = _addopts_without_cov(['--strict-markers', '--cov-report'])
         assert result == '--strict-markers'
 
+    def it_drops_a_negative_cov_fail_under_value(self) -> None:
+        """``--cov-fail-under`` always requires a value, even one that looks like a flag."""
+        result = _addopts_without_cov(['--cov-fail-under', '-1', '--import-mode=importlib'])
+        assert result == '--import-mode=importlib'
+
+    def it_drops_a_dash_prefixed_cov_report_value(self) -> None:
+        """``--cov-report`` always requires a value; a dash-prefixed one must not leak."""
+        result = _addopts_without_cov(['--cov-report', '-x', '--strict-markers'])
+        assert result == '--strict-markers'
+
+    def it_drops_values_for_consecutive_required_value_cov_options(self) -> None:
+        """Two required-value cov options in sequence each drop only their own value,
+        even when one of those values is dash-prefixed."""
+        result = _addopts_without_cov(['--cov-report', 'term', '--cov-fail-under', '-1', '--import-mode=importlib'])
+        assert result == '--import-mode=importlib'
+
 
 @pytest.mark.medium
 class DescribeCoverageSubprocessPreservesAddopts:

--- a/tests/plugin/test_plugin_addopts_preserve.py
+++ b/tests/plugin/test_plugin_addopts_preserve.py
@@ -85,6 +85,15 @@ class DescribeAddoptsWithoutCov:
         result = _addopts_without_cov(['-k', 'foo or bar'])
         assert result == "-k 'foo or bar'"
 
+    def it_drops_a_bare_cov_that_is_the_final_token(self) -> None:
+        """A value-taking cov option with nothing after it must not raise IndexError."""
+        assert _addopts_without_cov(['--cov']) == ''
+
+    def it_drops_a_value_taking_cov_option_that_is_the_final_token(self) -> None:
+        """``--cov-report`` as the last token has no value to consume; must not raise IndexError."""
+        result = _addopts_without_cov(['--strict-markers', '--cov-report'])
+        assert result == '--strict-markers'
+
 
 @pytest.mark.medium
 class DescribeCoverageSubprocessPreservesAddopts:


### PR DESCRIPTION
## Summary

The three follow-ups from the #436 coverage-addopts review, closing the test gaps and hardening the value-consumption heuristic.

### #444 — final-token boundary tests
Cover the `index < count` guard in `_addopts_without_cov` (a value-taking cov option as the last token). The guard was correct but untested/mutant-survivable; now covered by `it_drops_a_bare_cov_that_is_the_final_token` and `it_drops_a_value_taking_cov_option_that_is_the_final_token`.

### #445 — end-to-end verification
A real subprocess test proving pytest genuinely honors the re-injected `-o addopts=<...>` at runtime — uses a duplicate-basename project that only collects under `--import-mode=importlib`, plus a negative control. Previous tests stubbed the subprocess, so this closes the gap where nothing proved pytest respected the re-injection.

### #446 — harden the value-consumption heuristic (production fix)
Fixes a **silent mis-strip**: dash-prefixed values for required-value cov options (`--cov-fail-under -1`, `--cov-report -x`) were leaking into the re-injected addopts string. Introduces a three-way classification — optional-value (`--cov`, `nargs='?'`), flag-only (`_COV_FLAG_ONLY_OPTS`), and required-value (everything else) — matching pytest-cov's actual option semantics.

## Testing

- 26 tests in `test_plugin_addopts_preserve.py` (incl. 3 new RED→GREEN for #446).
- Adversarial QA introspected the installed pytest-cov 7.1.0 option table and ran ~25 empirical probes across classification boundaries, dash/negative values, interleaving, prefix-over-strip, and shlex round-trip — **0 bugs**. Confirmed the over-strip guard is exact-match (`--covariance-threshold` survives) and classification matches pytest-cov exactly.
- `uv run pytest tests -m small` → 1067 passed; `-m "small or medium"` → 1507 passed; mypy + ruff clean.

Closes #444
Closes #445
Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
