### PR TITLE
fix(explain): polish --gremlin-explain output edge cases (closes #420)

### DIFF
--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -1577,6 +1577,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # n
         logger.debug('pytest_sessionfinish: xdist Phase 2 generated %d gremlins', len(gremlin_session.gremlins))
 
     if not gremlin_session.gremlins:
+        if gremlin_session.explain_gremlin_id is not None:
+            print(
+                '--gremlin-explain: no gremlins were generated in this session (nothing to '
+                'explain). Check your `paths`/`--gremlin-targets` configuration.'
+            )
+            gremlin_session.enabled = False
         return
 
     _collect_coverage(gremlin_session, rootdir)

--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -2366,14 +2366,28 @@ def _covering_tests_for_gremlin(gremlin: Gremlin, gremlin_session: GremlinSessio
     return collector.coverage_map.get_tests(gremlin.file_path, gremlin.line_number)
 
 
+def _pluralize_test_count(count: int) -> str:
+    """Render a test count with the correctly pluralized noun.
+
+    Examples:
+        >>> _pluralize_test_count(0)
+        '0 tests'
+        >>> _pluralize_test_count(1)
+        '1 test'
+        >>> _pluralize_test_count(2)
+        '2 tests'
+    """
+    return f'{count} test' if count == 1 else f'{count} tests'
+
+
 def _print_explainer_header(gremlin: Gremlin, covering: set[str], selected: list[str]) -> None:
     """Print the banner plus the covering and selected lists for the diagnostic."""
     print(f'--gremlin-explain: diagnostic for {gremlin.gremlin_id}')
     print(f'  file: {gremlin.file_path}:{gremlin.line_number}')
-    print(f'  Covering set ({len(covering)} test(s)):')
+    print(f'  Covering set ({_pluralize_test_count(len(covering))}):')
     for key in sorted(covering):
         print(f'    {key!r}')
-    print(f'  Selected list ({len(selected)} test(s)):')
+    print(f'  Selected list ({_pluralize_test_count(len(selected))}):')
     for key in selected:
         print(f'    {key!r}')
 

--- a/src/pytest_gremlins/plugin.py
+++ b/src/pytest_gremlins/plugin.py
@@ -2348,6 +2348,9 @@ def _emit_selection_explainer(gremlin_session: GremlinSession) -> None:
 
     _print_explainer_header(target_gremlin, covering, selected)
 
+    if gremlin_session.no_coverage_filter:
+        print('  Note: coverage filter disabled -- all tests selected (--gremlin-no-coverage-filter).')
+
     if not covering_minus_selected and not selected_minus_runnable:
         print(
             '  Result: selection is consistent with covering set (no drift). '

--- a/tests/plugin/test_gremlin_explain.py
+++ b/tests/plugin/test_gremlin_explain.py
@@ -234,6 +234,66 @@ class DescribeEmitSelectionExplainerNoDrift:
 
 
 @pytest.mark.small
+class DescribeEmitSelectionExplainerNoCoverageFilter:
+    """Tests the explainer surfaces a mode-aware note when coverage filtering is disabled."""
+
+    def it_notes_coverage_filter_is_disabled(self, sample_gremlin):
+        collector = CoverageCollector()
+        covered_key = 'tests/test_target.py::test_zero_case'
+        collector.record_test_coverage(
+            covered_key,
+            {sample_gremlin.file_path: [sample_gremlin.line_number]},
+        )
+
+        session = GremlinSession(
+            enabled=True,
+            gremlins=[sample_gremlin],
+            no_coverage_filter=True,
+            test_node_ids={
+                covered_key: covered_key,
+                'tests/test_target.py::test_nonzero_case': 'tests/test_target.py::test_nonzero_case',
+            },
+            coverage_collector=collector,
+            explain_gremlin_id=sample_gremlin.gremlin_id,
+        )
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            _emit_selection_explainer(session)
+
+        output = buffer.getvalue()
+        assert 'coverage filter disabled -- all tests selected' in output
+
+    def it_omits_the_note_when_coverage_filter_is_enabled(self, sample_gremlin):
+        collector = CoverageCollector()
+        covered_key = 'tests/test_target.py::test_zero_case'
+        collector.record_test_coverage(
+            covered_key,
+            {sample_gremlin.file_path: [sample_gremlin.line_number]},
+        )
+
+        mock_selector = create_autospec(PrioritizedSelector, instance=True)
+        mock_selector.select_tests_prioritized.return_value = [covered_key]
+
+        session = GremlinSession(
+            enabled=True,
+            gremlins=[sample_gremlin],
+            no_coverage_filter=False,
+            test_node_ids={covered_key: covered_key},
+            coverage_collector=collector,
+            prioritized_selector=mock_selector,
+            explain_gremlin_id=sample_gremlin.gremlin_id,
+        )
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            _emit_selection_explainer(session)
+
+        output = buffer.getvalue()
+        assert 'coverage filter disabled' not in output
+
+
+@pytest.mark.small
 class DescribeEmitSelectionExplainerMissingGremlin:
     """Tests behaviour when the requested gremlin_id is not in the session."""
 

--- a/tests/plugin/test_gremlin_explain.py
+++ b/tests/plugin/test_gremlin_explain.py
@@ -32,6 +32,7 @@ from pytest_gremlins.plugin import (
     _covering_tests_for_gremlin,
     _emit_selection_explainer,
     _print_dropped_tests,
+    _print_explainer_header,
     _print_unrunnable_selections,
     pytest_addoption,
 )
@@ -146,11 +147,11 @@ class DescribeEmitSelectionExplainerDrift:
         # diagnostic corresponds to the right source location.
         assert f'  file: {sample_gremlin.file_path}:{sample_gremlin.line_number}' in output
         # Covering set shows the drifted key and its exact count.
-        assert 'Covering set (1 test(s)):' in output
+        assert 'Covering set (1 test):' in output
         assert "'tests/test_target.py::test_zero_case [custom-tag]'" in output
         # Selected list contains the non-drifted test; the drifted key was
         # silently dropped by the (simulated) selector — the exact #387 shape.
-        assert 'Selected list (1 test(s)):' in output
+        assert 'Selected list (1 test):' in output
         assert "'tests/test_target.py::test_nonzero_case'" in output
 
     def it_names_the_dropped_test_in_the_diff(self, sample_gremlin):
@@ -223,8 +224,8 @@ class DescribeEmitSelectionExplainerNoDrift:
         assert f'--gremlin-explain: diagnostic for {sample_gremlin.gremlin_id}' in output
         assert '  Result: selection is consistent with covering set (no drift).' in output
         # Covering set header shows the exact count, not a hand-wave.
-        assert 'Covering set (1 test(s)):' in output
-        assert 'Selected list (1 test(s)):' in output
+        assert 'Covering set (1 test):' in output
+        assert 'Selected list (1 test):' in output
         # No drift means no dropped-test breakdown is emitted.
         assert 'Covering minus selected' not in output
         assert 'Selected but not in test_node_ids' not in output
@@ -355,6 +356,36 @@ class DescribePrintDroppedTests:
             _print_dropped_tests([], runnable_candidates=[])
 
         assert buffer.getvalue() == ''
+
+
+@pytest.mark.small
+class DescribePrintExplainerHeaderPluralization:
+    """Tests that _print_explainer_header pluralizes the test count correctly."""
+
+    def it_uses_singular_test_for_a_single_covering_test(self, sample_gremlin):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            _print_explainer_header(sample_gremlin, covering={'tests/test_target.py::test_zero_case'}, selected=[])
+
+        assert 'Covering set (1 test):' in buffer.getvalue()
+
+    def it_uses_plural_tests_for_zero_covering_tests(self, sample_gremlin):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            _print_explainer_header(sample_gremlin, covering=set(), selected=[])
+
+        assert 'Covering set (0 tests):' in buffer.getvalue()
+
+    def it_uses_plural_tests_for_two_selected_tests(self, sample_gremlin):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            _print_explainer_header(
+                sample_gremlin,
+                covering=set(),
+                selected=['tests/test_target.py::test_zero_case', 'tests/test_target.py::test_nonzero_case'],
+            )
+
+        assert 'Selected list (2 tests):' in buffer.getvalue()
 
 
 @pytest.mark.small

--- a/tests/plugin/test_gremlin_explain_pytester.py
+++ b/tests/plugin/test_gremlin_explain_pytester.py
@@ -94,8 +94,8 @@ class DescribeGremlinExplainPytester:
         # Per-set breakdown must be structured (name + count + colon), not just a
         # bare word — a regression that dropped the counts would pass a plain
         # substring check.
-        assert re.search(r'Covering set \(\d+ test\(s\)\):', output), output
-        assert re.search(r'Selected list \(\d+ test\(s\)\):', output), output
+        assert re.search(r'Covering set \(\d+ tests?\):', output), output
+        assert re.search(r'Selected list \(\d+ tests?\):', output), output
         # Mutation loop is short-circuited: no per-gremlin progress after the diagnostic.
         post_explain = output.split('--gremlin-explain: diagnostic for', 1)[-1]
         assert 'Gremlin 1/' not in post_explain, post_explain

--- a/tests/plugin/test_gremlin_explain_pytester.py
+++ b/tests/plugin/test_gremlin_explain_pytester.py
@@ -126,3 +126,40 @@ class DescribeGremlinExplainPytester:
         # Pytest still exits cleanly: unknown id short-circuits mutation but
         # never fails the session on the user's behalf.
         assert result.ret == 0, output
+
+    def it_reports_no_gremlins_generated_for_zero_gremlin_session(self, pytester: pytest.Pytester) -> None:
+        """--gremlin-explain on a session with zero gremlins prints a mode-specific notice.
+
+        Points ``paths`` at a nonexistent module so gremlin generation produces
+        an empty list, then requests ``--gremlin-explain`` for an arbitrary id.
+        """
+        pytester.makepyfile(
+            test_target=('import pytest\n\n@pytest.mark.small\ndef test_trivial():\n    assert True\n'),
+        )
+        pytester.makepyprojecttoml(
+            """
+[tool.pytest-gremlins]
+paths = ["nonexistent_module.py"]
+"""
+        )
+        pytester.makeconftest(
+            """
+import pytest
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'small: fast unit tests')
+"""
+        )
+
+        result = pytester.runpytest(
+            '-p',
+            'pytest_gremlins',
+            '--gremlins',
+            '--gremlin-explain=g001',
+        )
+
+        output = result.stdout.str()
+        assert '--gremlin-explain: no gremlins were generated in this session' in output, output
+        assert 'Covering set' not in output, output
+        assert 'Selected list' not in output, output
+        assert result.ret == 0, output

--- a/tests/plugin/test_xdist_worker_guard.py
+++ b/tests/plugin/test_xdist_worker_guard.py
@@ -129,6 +129,53 @@ class DescribeSessionFinishBranches:
 
         mock_collect.assert_not_called()
 
+    def it_reports_no_gremlins_generated_when_explain_requested_and_gremlins_empty(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--gremlin-explain on a zero-gremlin session prints a mode-specific notice."""
+        session = _make_controller_session(tmp_path)
+
+        gs = GremlinSession(enabled=True, explain_gremlin_id='g001')
+        # gremlins is empty by default
+        _set_session(gs)
+
+        with patch('pytest_gremlins.plugin._collect_coverage') as mock_collect:
+            pytest_sessionfinish(session, exitstatus=0)
+
+        mock_collect.assert_not_called()
+        output = capsys.readouterr().out
+        assert '--gremlin-explain: no gremlins were generated in this session' in output
+
+    def it_disables_session_when_explain_requested_and_gremlins_empty(self, tmp_path: Path) -> None:
+        """The zero-gremlin explain notice disables the session like every other explain branch."""
+        session = _make_controller_session(tmp_path)
+
+        gs = GremlinSession(enabled=True, explain_gremlin_id='g001')
+        _set_session(gs)
+
+        with patch('pytest_gremlins.plugin._collect_coverage'):
+            pytest_sessionfinish(session, exitstatus=0)
+
+        assert gs.enabled is False
+
+    def it_stays_silent_when_explain_not_requested_and_gremlins_empty(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A plain zero-gremlin session (no --gremlin-explain) prints nothing extra."""
+        session = _make_controller_session(tmp_path)
+
+        gs = GremlinSession(enabled=True)
+        _set_session(gs)
+
+        with patch('pytest_gremlins.plugin._collect_coverage'):
+            pytest_sessionfinish(session, exitstatus=0)
+
+        assert capsys.readouterr().out == ''
+
     def it_calls_batch_testing_when_batch_enabled(self, tmp_path: Path) -> None:
         """When batch_enabled is True, _run_batch_mutation_testing is called."""
         session = _make_controller_session(tmp_path)


### PR DESCRIPTION
## Summary

Three edge-case fixes for the `--gremlin-explain <id>` diagnostic output (issue #420):

1. **Test-count pluralization** — a `_pluralize_test_count` helper renders "1 test" vs "2 tests" (and "0 tests"), replacing the hardcoded "test(s)". Applied at both the covering-count and selected-count sites.

2. **Zero-gremlin session** — when a session generates no gremlins, `--gremlin-explain` now prints "no gremlins were generated in this session" instead of silently emitting nothing. This is structurally separate from the existing "gremlin `<id>` not found" path (gremlins exist but the requested id doesn't), so the two messages never shadow each other.

3. **`--gremlin-no-coverage-filter` note** — when the coverage filter is disabled, the explainer now prints "coverage filter disabled -- all tests selected (--gremlin-no-coverage-filter)." after the covering/selected breakdown, clarifying why the selected list ignores the covering set.

## Testing

- New tests in `tests/plugin/test_gremlin_explain.py` (unit) and the pytester suite (e2e), including a zero-gremlin-session end-to-end test.
- Adversarial QA ran 6 probes: pluralization boundaries (0/1/N), the zero-gremlin-vs-not-found shadowing concern (confirmed separate paths), the no-coverage-filter note accuracy against the real selection logic, the combined no-filter+drift edge, empty-collection off-by-one, and string formatting — **0 bugs found**.
- `uv run pytest tests -m small` → 1070 passed; doctests on the new helpers pass; mypy + ruff clean.

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
