### PR TITLE
fix(cache): hash file contents as bytes

### DIFF
--- a/src/pytest_gremlins/cache/hasher.py
+++ b/src/pytest_gremlins/cache/hasher.py
@@ -56,8 +56,7 @@ class ContentHasher:
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        content = path.read_text(encoding='utf-8')
-        return self.hash_string(content)
+        return hashlib.sha256(path.read_bytes()).hexdigest()
 
     def hash_files(self, paths: list[Path]) -> dict[str, str]:
         """Hash multiple files and return a mapping of path to hash.

--- a/tests/cache/test_bug_hunting.py
+++ b/tests/cache/test_bug_hunting.py
@@ -4,6 +4,8 @@ These tests expose potential bugs found during code review.
 Following TDD: write failing test first, then fix the bug.
 """
 
+import hashlib
+
 import pytest
 
 from pytest_gremlins.cache.hasher import ContentHasher
@@ -35,19 +37,14 @@ class DescribeHasherBugs:
         # Currently they're the same, which is a bug
         assert combined_empty == string_empty  # This passes, showing the bug exists
 
-    def it_raises_clear_error_for_binary_file_content(self, tmp_path):
-        """hash_file raises UnicodeDecodeError for binary files.
-
-        BUG: hash_file uses read_text() which fails on binary files.
-        The error message is not helpful for users.
-        """
+    def it_hashes_binary_file_content(self, tmp_path):
+        """hash_file hashes binary files without decoding them."""
         hasher = ContentHasher()
         binary_file = tmp_path / 'test.pyc'
-        binary_file.write_bytes(b'\x00\x01\x02\x03\xff\xfe')
+        content = b'\x00\x01\x02\x03\xff\xfe'
+        binary_file.write_bytes(content)
 
-        # Currently raises UnicodeDecodeError - not very helpful
-        with pytest.raises(UnicodeDecodeError):
-            hasher.hash_file(binary_file)
+        assert hasher.hash_file(binary_file) == hashlib.sha256(content).hexdigest()
 
 
 @pytest.mark.medium

--- a/tests/cache/test_hasher.py
+++ b/tests/cache/test_hasher.py
@@ -144,6 +144,15 @@ class DescribeContentHasherFileIO:
 
         assert hasher.hash_file(lf_path) != hasher.hash_file(crlf_path)
 
+    def it_hashes_non_utf8_source_bytes(self, tmp_path):
+        """hash_file hashes valid PEP 263 source without decoding it."""
+        hasher = ContentHasher()
+        content = b"# -*- coding: latin-1 -*-\nname = 'caf\xe9'\n"
+        file_path = tmp_path / 'latin1.py'
+        file_path.write_bytes(content)
+
+        assert hasher.hash_file(file_path) == hashlib.sha256(content).hexdigest()
+
     def it_raises_for_missing_file(self, tmp_path):
         """hash_file raises FileNotFoundError for missing files."""
         hasher = ContentHasher()


### PR DESCRIPTION
## Summary

Hash incremental cache keys from raw bytes so valid non-UTF-8 Python source no longer raises `UnicodeDecodeError`. Fixes #455.

## Changes

- Hash file bytes directly with SHA-256.
- Cover PEP 263 Latin-1 source and arbitrary binary content.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Fixes #455

## Testing

- [ ] All existing tests pass
- [x] Added new tests for this change
- [x] Manually tested

The regression fails with `UnicodeDecodeError` before the fix and passes after it. All 99 cache tests, Ruff, formatting, and mypy pass. The full suite reaches 1,491 passes; its 32 process-pool failures are identical on the baseline under the network/process-denied sandbox.

## Checklist

- [x] Code follows project style guidelines (ruff, mypy pass)
- [x] Self-reviewed my own code
- [x] Tests written FIRST (TDD)
- [x] Documentation updated if needed
- [x] No new warnings introduced
