### PR TITLE
fix: clear the three release blockers — hasher test, Windows CI integrity, pygments CVE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage
+        shell: bash
         env:
           COVERAGE_PROCESS_START: pyproject.toml
           PYTHONPATH: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         run: uv sync
 
       - name: Run pip-audit
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539  # pygments: no fix available yet
+        run: uv run pip-audit
 
   attrs-smoke:
     name: Attrs Smoke Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage (small + medium, matching PR CI)
+        shell: bash
         env:
           COVERAGE_PROCESS_START: pyproject.toml
           PYTHONPATH: .

--- a/src/pytest_gremlins/cache/hasher.py
+++ b/src/pytest_gremlins/cache/hasher.py
@@ -41,6 +41,12 @@ class ContentHasher:
     def hash_file(self, path: Path) -> str:
         """Hash a file's content and return its hex digest.
 
+        Equivalence with :meth:`hash_string` for the same logical content
+        is guaranteed only when the file is LF-encoded UTF-8 text. Files
+        with CRLF line endings or non-UTF-8 encodings are not guaranteed
+        to produce the same hash as ``hash_string`` on the equivalent
+        string.
+
         Args:
             path: Path to the file to hash.
 

--- a/tests/cache/test_hasher.py
+++ b/tests/cache/test_hasher.py
@@ -4,6 +4,8 @@ Content hashing is the foundation of incremental analysis. Files with
 identical content produce identical hashes, enabling cache lookups.
 """
 
+import hashlib
+
 import pytest
 
 from pytest_gremlins.cache.hasher import ContentHasher
@@ -87,17 +89,60 @@ class DescribeContentHasherFileIO:
         assert isinstance(result, str)
         assert len(result) == 64  # SHA-256 produces 64 hex characters
 
-    def it_matches_hash_file_output_to_hash_string(self, tmp_path):
-        """hash_file produces same result as hash_string for same content."""
+    def it_matches_hash_file_output_to_hash_string_for_lf_source(self, tmp_path):
+        """hash_file matches hash_string for LF-encoded content.
+
+        This equivalence is scoped to LF-encoded UTF-8 source: it does not
+        claim anything about CRLF or non-UTF-8 files. See #469.
+        """
         hasher = ContentHasher()
         content = 'class MyClass:\n    pass\n'
         file_path = tmp_path / 'test.py'
-        file_path.write_text(content)
+        file_path.write_bytes(content.encode('utf-8'))
 
         file_hash = hasher.hash_file(file_path)
         string_hash = hasher.hash_string(content)
 
         assert file_hash == string_hash
+
+    @pytest.mark.xfail(
+        reason='passes once #465 lands: hash_file will hash raw bytes instead of read_text() output',
+        strict=False,
+    )
+    def it_hashes_file_content_as_raw_bytes(self, tmp_path):
+        """hash_file equals the SHA-256 digest of the file's raw bytes.
+
+        Fails on current main because hash_file still hashes read_text()
+        output, which applies universal-newline translation. Remove the
+        xfail marker once #465 merges.
+        """
+        hasher = ContentHasher()
+        file_path = tmp_path / 'test.py'
+        file_path.write_bytes(b'class MyClass:\r\n    pass\r\n')
+
+        result = hasher.hash_file(file_path)
+
+        assert result == hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+    @pytest.mark.xfail(
+        reason='passes once #465 lands: hash_file will hash raw bytes instead of read_text() output',
+        strict=False,
+    )
+    def it_hashes_crlf_and_lf_files_differently_for_same_logical_content(self, tmp_path):
+        """A CRLF file and an LF file with the same logical content hash differently.
+
+        Fails on current main because read_text()'s universal-newline
+        translation makes CRLF and LF files hash identically. Remove the
+        xfail marker once #465 merges.
+        """
+        hasher = ContentHasher()
+        logical_content = 'class MyClass:\n    pass\n'
+        lf_path = tmp_path / 'lf.py'
+        crlf_path = tmp_path / 'crlf.py'
+        lf_path.write_bytes(logical_content.encode('utf-8'))
+        crlf_path.write_bytes(logical_content.replace('\n', '\r\n').encode('utf-8'))
+
+        assert hasher.hash_file(lf_path) != hasher.hash_file(crlf_path)
 
     def it_raises_for_missing_file(self, tmp_path):
         """hash_file raises FileNotFoundError for missing files."""

--- a/uv.lock
+++ b/uv.lock
@@ -1567,11 +1567,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears all three known release blockers. Ordered deliberately, and the order matters.

## 1. `395dfe8` — re-scope the hasher test (closes #469)

`it_matches_hash_file_output_to_hash_string` wrote its fixture with `write_text()`, i.e. the platform-default newline. Under today's `read_text()`-based `hash_file` that passes everywhere, because universal-newline translation cancels it out. Once #465 lands and `hash_file` hashes raw bytes, the Windows CRLF fixture is compared against an LF string and the assertion fails.

Re-scoped to write explicit LF bytes and renamed to `..._for_lf_source` to state its real scope. Verified to pass **both** against current `read_text()` hashing and against #465's `read_bytes()` version — which is what makes landing this first safe.

Added two `xfail(strict=False)` tests pinning the post-#465 contract, plus a docstring-only note on `hash_file` that `hash_string` equivalence holds only for LF-encoded UTF-8. **`hasher.py` logic is unchanged** — the production fix is #465's to make.

## 2. `003fff1` — make windows-latest able to fail (closes #468)

The "Run tests with coverage" step is a multi-line `run:` with no `shell:` override. On Windows that runs under `pwsh -command`, which does not halt on a native command's non-zero exit — so a pytest failure was overwritten by the exit code of the final `coverage` command. **All four Windows jobs have reported `success` regardless of test outcome for this workflow's entire history**, and `release.yml` shared the defect, so releases were gated on the same fiction.

`shell: bash` maps to `bash --noprofile --norc -eo pipefail` on Windows, so `-e` aborts at the first failure. Applied to `ci.yml` and `release.yml`. Every other multi-line `run:` block across all six workflow files was audited and is pinned to `ubuntu-latest`, where bash is already the default — no other instance exists.

> **Correction:** commit `003fff1`'s message states this must land *before* #469. That is backwards — #469 must land first, or Windows becomes load-bearing before the fixed test is in place. The commit order in this branch is correct; only that message's rationale is inverted.

## 3. `9f9b743` — pygments CVE (closes #471)

`pygments` PYSEC-2026-2987 was suppressed by a `# pygments: no fix available yet` comment that expired when 2.20.0 shipped. Unlike the pillow/click bumps in #472 (docs tooling), **pygments is a runtime dependency of pytest and ships in every published wheel**. Bumped to 2.20.0 with zero collateral lockfile changes; the `--ignore-vuln` flag and its stale comment are removed so `pip-audit` runs unsuppressed.

## ⚠️ Expect the Windows matrix to be informative

This PR produces the **first trustworthy Windows CI result in this repository's history**. Adversarial QA flagged two surfaces that have never been validated by a job capable of failing:

- `fail_under = 97` now genuinely gates the Windows legs, and coverage can differ by platform
- Windows-specific timing thresholds in `test_pool_optimization_benefits.py:137-138` and `test_optimized_pool.py:104` were written defensively and never actually exercised

**If Windows goes red here, that is a pre-existing failure this PR reveals, not one it introduces.** It would still need fixing before release.

## Verification

- `pytest -m "small or medium and not wip"` → 1522 passed, 2 skipped, 2 xfailed
- doctests → 38 passed, 2 skipped
- `mypy` clean · `ruff check` clean · `ruff format --check` 189 files formatted
- `pip-audit` (no ignore flags) → no known vulnerabilities
- `uv lock --check` → clean, no drift

## Unblocks

PR #465 can then merge with its gauntlet passing honestly — and validated by a Windows matrix that can actually fail.

Closes #469
Closes #468
Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)