### PR TITLE
test: finalize hasher test suite after #465 (closes #475)

### DIFF
--- a/tests/cache/test_hasher.py
+++ b/tests/cache/test_hasher.py
@@ -105,17 +105,8 @@ class DescribeContentHasherFileIO:
 
         assert file_hash == string_hash
 
-    @pytest.mark.xfail(
-        reason='passes once #465 lands: hash_file will hash raw bytes instead of read_text() output',
-        strict=False,
-    )
     def it_hashes_file_content_as_raw_bytes(self, tmp_path):
-        """hash_file equals the SHA-256 digest of the file's raw bytes.
-
-        Fails on current main because hash_file still hashes read_text()
-        output, which applies universal-newline translation. Remove the
-        xfail marker once #465 merges.
-        """
+        """hash_file equals the SHA-256 digest of the file's raw bytes."""
         hasher = ContentHasher()
         file_path = tmp_path / 'test.py'
         file_path.write_bytes(b'class MyClass:\r\n    pass\r\n')
@@ -124,17 +115,8 @@ class DescribeContentHasherFileIO:
 
         assert result == hashlib.sha256(file_path.read_bytes()).hexdigest()
 
-    @pytest.mark.xfail(
-        reason='passes once #465 lands: hash_file will hash raw bytes instead of read_text() output',
-        strict=False,
-    )
     def it_hashes_crlf_and_lf_files_differently_for_same_logical_content(self, tmp_path):
-        """A CRLF file and an LF file with the same logical content hash differently.
-
-        Fails on current main because read_text()'s universal-newline
-        translation makes CRLF and LF files hash identically. Remove the
-        xfail marker once #465 merges.
-        """
+        """A CRLF file and an LF file with the same logical content hash differently."""
         hasher = ContentHasher()
         logical_content = 'class MyClass:\n    pass\n'
         lf_path = tmp_path / 'lf.py'
@@ -175,6 +157,45 @@ class DescribeContentHasherFileIO:
         assert str(file1) in result
         assert str(file2) in result
         assert result[str(file1)] != result[str(file2)]
+
+
+@pytest.mark.medium
+class DescribeContentHasherFileErrors:
+    """File I/O edge cases for ContentHasher — require real filesystem access."""
+
+    def it_raises_is_a_directory_error_for_directories(self, tmp_path):
+        """hash_file raises IsADirectoryError when given a directory."""
+        hasher = ContentHasher()
+
+        with pytest.raises(IsADirectoryError):
+            hasher.hash_file(tmp_path)
+
+    def it_hashes_empty_files(self, tmp_path):
+        """hash_file returns the SHA-256 of empty bytes for an empty file."""
+        hasher = ContentHasher()
+        file_path = tmp_path / 'empty.py'
+        file_path.write_bytes(b'')
+
+        assert hasher.hash_file(file_path) == hashlib.sha256(b'').hexdigest()
+
+    def it_follows_symlinks_to_target_content(self, tmp_path):
+        """hash_file hashes the symlink target's content, not the link itself."""
+        hasher = ContentHasher()
+        target = tmp_path / 'target.py'
+        target.write_bytes(b'def foo(): pass\n')
+        link = tmp_path / 'link.py'
+        link.symlink_to(target)
+
+        assert hasher.hash_file(link) == hasher.hash_file(target)
+
+    def it_hashes_utf8_bom_files_by_raw_bytes(self, tmp_path):
+        """hash_file includes the UTF-8 BOM in the digest."""
+        hasher = ContentHasher()
+        content = b'\xef\xbb\xbfdef foo(): pass\n'
+        file_path = tmp_path / 'bom.py'
+        file_path.write_bytes(content)
+
+        assert hasher.hash_file(file_path) == hashlib.sha256(content).hexdigest()
 
 
 @pytest.mark.small

--- a/tests/cache/test_hasher.py
+++ b/tests/cache/test_hasher.py
@@ -163,11 +163,16 @@ class DescribeContentHasherFileIO:
 class DescribeContentHasherFileErrors:
     """File I/O edge cases for ContentHasher — require real filesystem access."""
 
-    def it_raises_is_a_directory_error_for_directories(self, tmp_path):
-        """hash_file raises IsADirectoryError when given a directory."""
+    def it_raises_os_error_for_directories(self, tmp_path):
+        """hash_file raises OSError when given a directory.
+
+        IsADirectoryError is raised on POSIX systems, PermissionError on
+        Windows. Both are subclasses of OSError, so we assert the portable
+        contract without specifying the platform-specific subclass.
+        """
         hasher = ContentHasher()
 
-        with pytest.raises(IsADirectoryError):
+        with pytest.raises(OSError):  # noqa: PT011
             hasher.hash_file(tmp_path)
 
     def it_hashes_empty_files(self, tmp_path):


### PR DESCRIPTION
Test-only follow-up now that PR #465 (byte-hashing) has merged. `tests/cache/test_hasher.py` only; `src/` untouched.

## Part 1 — remove two now-redundant xfail markers (was release-blocking)

#473 marked `it_hashes_file_content_as_raw_bytes` and `it_hashes_crlf_and_lf_files_differently_for_same_logical_content` as `@pytest.mark.xfail(strict=False)` because they pinned behavior from the then-unmerged #465. #465 has landed, so both were **always-xpassing** — an xfail that never fails gives zero regression protection while reading as coverage (the exact "passes for the wrong reason" trap #469 existed to fix).

Markers removed; both are now ordinary passing tests. The overall suite's `xpassed` count drops from 2 to **0**.

**These are genuinely load-bearing now** — the adversarial QA gate proved it by running each assertion against both implementations: under the merged `read_bytes()` both pass; under a `read_text().encode()` regression (pre-#465 behavior) both fail. So they would catch a regression, which is the whole justification for un-marking them.

## Part 2 — four salvaged edge-case tests

Added in a new `DescribeContentHasherFileErrors` class (matching the file's I/O-test convention). These were written during #465's original gauntlet but never committed:

- directory input → raises `OSError` (`IsADirectoryError` on POSIX, `PermissionError` on Windows — asserted at the portable `OSError` level after the Windows CI caught the platform difference)
- empty file → `sha256(b'')`
- symlink → hashes the target's content (real `symlink_to`)
- UTF-8 BOM → included in the digest (would fail under `utf-8-sig` stripping)

## Verification

- `pytest tests/cache/test_hasher.py -v` → 21 passed, **0 xfail/0 xpass**
- `pytest tests -m "small or medium and not wip"` → 1529 passed, 0 failed, 2 skipped, **0 xpassed** (was 2)
- `mypy src/pytest_gremlins` clean · `ruff check tests` + `format --check` clean

## Release

This was the last release-blocking item. After merge, the only remaining release step is the CHANGELOG entry.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
