### PR TITLE
docs: rebuild the execution-loop diagram as pytest-gremlins internals

### DIFF
--- a/docs/architecture/gremlin-execution-loop.md
+++ b/docs/architecture/gremlin-execution-loop.md
@@ -1,0 +1,20 @@
+# pytest-gremlins internals – per‑gremlin execution loop
+
+```mermaid
+sequenceDiagram
+    participant TestRunner
+    participant InstrumentedCode as Instrumented\nCode (in memory)
+    participant TestProcess as Test\nSubprocess
+
+    Note over TestRunner,InstrumentedCode: 1. Instrument code once\n(all mutations embedded)
+    TestRunner->>InstrumentedCode: Import instrumented module
+    InstrumentedCode-->>TestRunner: Module loaded
+
+    loop For each gremlin N
+        TestRunner->>TestRunner: 2. Set ACTIVE_GREMLIN=N
+        TestRunner->>TestProcess: 3. Run tests in subprocess
+        Note over TestProcess: Uses same instrumented code\nChecks ACTIVE_GREMLIN env var
+        TestProcess-->>TestRunner: Test results
+        Note over TestRunner,TestProcess: 4. Change env var\n5. Repeat (no I/O, no reloads)
+    end
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
       - North Star: design/NORTH_STAR.md
       - Operators Design: design/OPERATORS.md
       - Agent Guidelines: design/AGENT_GUIDELINES.md
+      - Execution Loop: architecture/gremlin-execution-loop.md
       - Performance Analysis: performance/profiling-report.md
 
 # Extra Configuration


### PR DESCRIPTION
# docs: rebuild the execution-loop diagram as pytest-gremlins internals

## Summary

This PR adds a new diagram showing the per-gremlin execution loop that demonstrates how pytest-gremlins achieves its speed through mutation switching. The diagram illustrates that code is instrumented once with all mutations embedded, and then each mutation is tested by simply changing the ACTIVE_GREMLIN environment variable - eliminating file I/O and module reloading during the testing loop.

Fixes #467

## Changes

- Added new file: docs/architecture/gremlin-execution-loop.md containing a Mermaid sequence diagram
- Updated mkdocs.yml navigation to include the new diagram in the Architecture section
- Diagram shows: 1. Instrument code once (all mutations embedded) → 2. Set ACTIVE_GREMLIN=N → 3. Run tests in subprocess → 4. Change env var → 5. Repeat (no I/O, no reloads)
- Verified the diagram contains no references to mutmut or other competing tools
- Diagram is clearly labeled as internals (not user workflow)
- Ran `mkdocs build --strict` to confirm documentation builds without errors

## Testing

- Built documentation with: `source .venv/bin/activate && mkdocs build --strict`
- Build completed successfully in ~3 seconds with only expected warnings about MkDocs 2.0 incompatibility
- Verified the new page appears in the site structure under Architecture section
- Confirmed Mermaid diagram renders correctly in the generated HTML

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
